### PR TITLE
Add multi-language PII redaction, OCB custom builds, and OTTL recipes

### DIFF
--- a/skills/otel-collector/SKILL.md
+++ b/skills/otel-collector/SKILL.md
@@ -31,6 +31,7 @@ Expert guidance for configuring and deploying the OpenTelemetry Collector to rec
 | [raw-manifests](./rules/deployment/raw-manifests.md) | Raw Kubernetes manifests — DaemonSet, Deployment, RBAC, Docker Compose |
 | [sampling](./rules/sampling.md) | Sampling — head, tail, load balancing |
 | [red-metrics](./rules/red-metrics.md) | RED metrics — span-derived request rate, error rate, duration histograms |
+| [custom-builds](./rules/custom-builds.md) | Custom Collector builds — OCB manifest, container images, CI pipeline |
 
 ## Key principles
 
@@ -74,6 +75,7 @@ Expert guidance for configuring and deploying the OpenTelemetry Collector to rec
 | Keep errors and slow traces, drop the rest | [sampling](./rules/sampling.md) |
 | Redact sensitive data in the pipeline | [processors](./rules/processors.md#sensitive-data-redaction) |
 | Generate RED metrics from traces | [red-metrics](./rules/red-metrics.md) |
+| Build a custom Collector binary | [custom-builds](./rules/custom-builds.md) |
 
 ## Official documentation
 

--- a/skills/otel-collector/rules/custom-builds.md
+++ b/skills/otel-collector/rules/custom-builds.md
@@ -1,0 +1,177 @@
+---
+title: "Custom Collector builds"
+impact: MEDIUM
+tags:
+  - ocb
+  - custom-build
+  - collector-builder
+  - container-image
+---
+
+# Custom Collector builds
+
+The OpenTelemetry Collector Builder (OCB) creates custom Collector binaries that include only the components you need.
+Use a custom build when the standard `otelcol-contrib` distribution includes components you do not use and you need to reduce binary size, enforce an allow-list of processors, or include proprietary components.
+
+## When to use a custom build
+
+Use the decision process below.
+Stop at the first match.
+
+1. **Do you need a component not in `otelcol-contrib`?** (e.g., a proprietary exporter or an internal receiver.)
+   Yes → custom build required.
+2. **Do you need to restrict which components are available** to prevent operators from enabling unapproved processors or exporters?
+   Yes → custom build recommended.
+3. **Is the `otelcol-contrib` binary too large** for your deployment constraints (e.g., resource-limited edge nodes, serverless)?
+   Yes → custom build recommended.
+4. **None of the above apply.**
+   Use `otelcol-contrib` or the [Collector Helm chart](./deployment/collector-helm-chart.md) with the default image.
+
+## OCB manifest
+
+The OCB manifest (`builder-config.yaml`) declares the Collector distribution metadata and the components to include.
+Every component is a Go module with a version.
+
+```yaml
+dist:
+  name: my-otelcol
+  description: Custom Collector for Acme Corp
+  output_path: ./dist
+  otelcol_version: 0.120.0
+
+exporters:
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.120.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.120.0
+
+receivers:
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.120.0
+
+processors:
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.120.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.120.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.120.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.120.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.120.0
+
+extensions:
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.120.0
+  - gomod: go.opentelemetry.io/collector/extension/healthcheckextension v0.120.0
+
+connectors: []
+```
+
+### Version alignment
+
+All component versions and the `otelcol_version` must be compatible.
+Core components (under `go.opentelemetry.io/collector/`) use the same version as `otelcol_version`.
+Contrib components (under `github.com/open-telemetry/opentelemetry-collector-contrib/`) use the matching contrib release tag.
+
+Mixing versions causes Go module dependency conflicts at build time.
+
+### Finding component module paths
+
+1. Core components: see the [opentelemetry-collector](https://github.com/open-telemetry/opentelemetry-collector) repository.
+2. Contrib components: see the [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) repository.
+3. Use the [OpenTelemetry Registry](https://opentelemetry.io/ecosystem/registry/?language=collector) to search by component name.
+
+## Building
+
+### Install OCB
+
+```bash
+go install go.opentelemetry.io/collector/cmd/builder@v0.120.0
+```
+
+The binary is installed as `builder`.
+Some older documentation refers to it as `ocb` — the tool is the same.
+
+### Build the binary
+
+```bash
+builder --config builder-config.yaml
+```
+
+This generates a Go project in `output_path`, resolves dependencies, and compiles the Collector binary.
+The resulting binary is at `./dist/my-otelcol` (matching `dist.name`).
+
+### Validate before building
+
+```bash
+builder --config builder-config.yaml --skip-compilation
+```
+
+This resolves Go modules and checks for version conflicts without compiling.
+Use it in CI to catch dependency issues early.
+
+## Container image
+
+Build a container image from the compiled binary to deploy to Kubernetes or Docker.
+
+```dockerfile
+FROM alpine:3.21 AS certs
+RUN apk add --no-cache ca-certificates
+
+FROM scratch
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY dist/my-otelcol /otelcol
+ENTRYPOINT ["/otelcol"]
+CMD ["--config", "/etc/otelcol/config.yaml"]
+```
+
+### Multi-architecture images
+
+Build for both `amd64` and `arm64` to support mixed-architecture clusters.
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --tag registry.example.com/my-otelcol:0.120.0 \
+  --push .
+```
+
+This requires cross-compiling the Go binary for each target architecture before building the image.
+Set `GOOS` and `GOARCH` during the OCB build step:
+
+```bash
+GOOS=linux GOARCH=amd64 builder --config builder-config.yaml --output-path ./dist/linux-amd64
+GOOS=linux GOARCH=arm64 builder --config builder-config.yaml --output-path ./dist/linux-arm64
+```
+
+Then use a multi-stage Dockerfile that copies the correct binary per platform.
+
+## CI pipeline
+
+A minimal CI workflow for custom Collector builds:
+
+1. **Validate** — run `builder --config builder-config.yaml --skip-compilation` to check for module conflicts.
+2. **Build** — compile the binary for each target architecture.
+3. **Test** — run the binary with a minimal config and the `--dry-run` flag (available since v0.104.0) to verify the configuration loads without starting receivers.
+4. **Package** — build and push the container image.
+5. **Deploy** — update the Collector image reference in your Kubernetes manifests or Helm values.
+
+```yaml
+# Example GitHub Actions step
+- name: Validate OCB manifest
+  run: builder --config builder-config.yaml --skip-compilation
+
+- name: Build Collector
+  run: builder --config builder-config.yaml
+
+- name: Smoke test
+  run: ./dist/my-otelcol --config test-config.yaml --dry-run
+```
+
+## Common issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `module requires Go 1.X` | OCB version requires a newer Go toolchain | Update Go to the version required by the OCB release |
+| `ambiguous import` or `module version mismatch` | Component versions do not match `otelcol_version` | Align all component versions to the same release |
+| Binary is unexpectedly large | Too many components included | Remove unused components from the manifest |
+| `unknown component` at runtime | Config references a component not in the manifest | Add the missing component to the manifest and rebuild |
+
+## References
+
+- [OpenTelemetry Collector Builder documentation](https://opentelemetry.io/docs/collector/custom-collector/)
+- [OCB source and releases](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder)
+- [Collector contrib components](https://github.com/open-telemetry/opentelemetry-collector-contrib)

--- a/skills/otel-instrumentation/rules/sensitive-data.md
+++ b/skills/otel-instrumentation/rules/sensitive-data.md
@@ -80,6 +80,33 @@ function redactSensitiveParams(url, sensitiveKeys) {
 span.setAttribute('url.full', redactSensitiveParams(req.url, ['token', 'api_key', 'session']));
 ```
 
+### URL path parameterization
+
+URL paths that embed entity IDs produce high-cardinality span names and attributes.
+Replace dynamic path segments with placeholders before setting `http.route` or `url.full`.
+
+```go
+import "regexp"
+
+var (
+	reNumericID = regexp.MustCompile(`/\d+`)
+	reUUID      = regexp.MustCompile(`/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)
+)
+
+// sanitizeHTTPRoute replaces numeric IDs and UUIDs with low-cardinality placeholders.
+func sanitizeHTTPRoute(path string) string {
+	path = reUUID.ReplaceAllString(path, "/{uuid}")
+	path = reNumericID.ReplaceAllString(path, "/{id}")
+	return path
+}
+
+// Usage
+span.SetAttributes(attribute.String("http.route", sanitizeHTTPRoute(r.URL.Path)))
+```
+
+Most HTTP framework instrumentations derive `http.route` from the router pattern automatically (e.g., `/users/:id` in Express, `{id}` in Go chi).
+Use path parameterization only when the instrumentation library does not normalize the route — for example, when using `http.ServeMux` in Go before version 1.22 or a custom routing layer.
+
 ### Database query sanitization
 
 Database instrumentation libraries may capture full query text, including literal parameter values.
@@ -91,6 +118,27 @@ span.setAttribute('db.query.text', "SELECT * FROM users WHERE email = 'alice@exa
 
 // GOOD: parameterized query — no literal values
 span.setAttribute('db.query.text', 'SELECT * FROM users WHERE email = $1');
+```
+
+Java — sanitize queries by replacing string literals and numeric values with placeholders:
+
+```java
+import java.util.regex.Pattern;
+
+public class DbQuerySanitizer {
+    private static final Pattern STRING_LITERAL = Pattern.compile("'[^']*'");
+    private static final Pattern NUMERIC_LITERAL = Pattern.compile("\\b\\d+(\\.\\d+)?\\b");
+
+    public static String sanitize(String query) {
+        if (query == null) return "unknown";
+        String sanitized = STRING_LITERAL.matcher(query).replaceAll("?");
+        sanitized = NUMERIC_LITERAL.matcher(sanitized).replaceAll("?");
+        return sanitized.length() > 1000 ? sanitized.substring(0, 1000) + "..." : sanitized;
+    }
+}
+
+// Usage
+span.setAttribute("db.query.text", DbQuerySanitizer.sanitize(sql));
 ```
 
 Follow this decision process when the auto-instrumentation library captures unsanitized queries:
@@ -140,6 +188,21 @@ function hashForTelemetry(value, key) {
 
 // Use the hash as the attribute value
 span.setAttribute('user.id', hashForTelemetry(user.email, process.env.TELEMETRY_HASH_KEY));
+```
+
+Python — the same HMAC approach:
+
+```python
+import hmac
+import hashlib
+import os
+
+def hash_for_telemetry(value: str) -> str:
+    key = os.environ["TELEMETRY_HASH_KEY"].encode()
+    return hmac.new(key, value.encode(), hashlib.sha256).hexdigest()
+
+# Usage
+span.set_attribute("user.id", hash_for_telemetry(user.email))
 ```
 
 Store the mapping between hashes and original values in a separate, access-controlled system — never in the observability backend.
@@ -220,6 +283,45 @@ provider.addSpanProcessor(new BatchSpanProcessor(new OTLPTraceExporter()));
 provider.register();
 ```
 
+Python — equivalent `SpanProcessor`:
+
+```python
+from opentelemetry.sdk.trace.export import SpanProcessor
+from urllib.parse import urlparse, urlunparse
+
+SENSITIVE_ATTRIBUTES = [
+    "http.request.header.authorization",
+    "http.request.header.cookie",
+    "http.response.header.set-cookie",
+]
+
+class SensitiveDataRedactingSpanProcessor(SpanProcessor):
+    def on_end(self, span):
+        for attr in SENSITIVE_ATTRIBUTES:
+            if attr in span.attributes:
+                span.attributes[attr] = "REDACTED"
+
+        url = span.attributes.get("url.full")
+        if isinstance(url, str):
+            try:
+                parsed = urlparse(url)
+                span.attributes["url.full"] = urlunparse(parsed._replace(query=""))
+            except Exception:
+                pass
+```
+
+Register it before the export processor:
+
+```python
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+provider = TracerProvider()
+provider.add_span_processor(SensitiveDataRedactingSpanProcessor())
+provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+```
+
 ### When to use a span processor vs other approaches
 
 | Approach | Use when |
@@ -242,6 +344,81 @@ The [otel-ottl](../../otel-ottl/SKILL.md) skill covers how to write OTTL express
 
 Treat Collector-side redaction as a safety net, not a substitute for source-level sanitization.
 The Collector processes telemetry after it has been serialized and exported — the data has already left the application process and traversed the network.
+
+## Log body sanitization
+
+Log messages assembled from user-controlled data or error details can contain credit card numbers, government identifiers, JWTs, or API keys.
+Apply pattern-based redaction before emitting log records.
+
+```javascript
+const REDACTION_PATTERNS = [
+  // Credit card numbers (Visa, Mastercard, Amex)
+  { pattern: /\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b/g, replacement: '****-****-****-****' },
+  // US Social Security Numbers
+  { pattern: /\b\d{3}-\d{2}-\d{4}\b/g, replacement: '***-**-****' },
+  // JWT tokens
+  { pattern: /\beyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*/g, replacement: 'JWT_REDACTED' },
+  // API keys with common prefixes
+  { pattern: /\b(?:sk_|pk_|key_)[a-zA-Z0-9_-]{20,}/g, replacement: 'API_KEY_REDACTED' },
+];
+
+function sanitizeLogMessage(message) {
+  let sanitized = message;
+  for (const { pattern, replacement } of REDACTION_PATTERNS) {
+    sanitized = sanitized.replace(pattern, replacement);
+  }
+  return sanitized;
+}
+```
+
+Use this function wherever log messages are assembled from dynamic data.
+It does not replace structured logging best practices (selecting explicit fields) — it catches PII that leaks through despite explicit field selection, for example when an upstream library logs a full error message containing user input.
+
+## Testing redaction
+
+Write tests that verify sensitive data does not survive the redaction pipeline.
+Tests prevent regressions when new attributes are added or instrumentation libraries are updated.
+
+```javascript
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+
+describe('SensitiveDataRedactingSpanProcessor', () => {
+  let exporter;
+  let provider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SensitiveDataRedactingSpanProcessor());
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    provider.register();
+  });
+
+  it('redacts authorization headers', () => {
+    const tracer = provider.getTracer('test');
+    const span = tracer.startSpan('test');
+    span.setAttribute('http.request.header.authorization', 'Bearer secret-token');
+    span.end();
+
+    const [exported] = exporter.getFinishedSpans();
+    expect(exported.attributes['http.request.header.authorization']).toBe('REDACTED');
+  });
+
+  it('strips query parameters from url.full', () => {
+    const tracer = provider.getTracer('test');
+    const span = tracer.startSpan('test');
+    span.setAttribute('url.full', 'https://example.com/cb?token=secret&ref=home');
+    span.end();
+
+    const [exported] = exporter.getFinishedSpans();
+    expect(exported.attributes['url.full']).toBe('https://example.com/cb');
+  });
+});
+```
+
+Run these tests in CI alongside application tests.
+If a test fails, a sensitive attribute has been introduced that the redaction processor does not cover.
 
 ## Anti-patterns
 
@@ -285,6 +462,24 @@ span.setStatus({
   message: 'ValidationError: invalid email format',
 });
 ```
+
+## Compliance quick reference
+
+When a compliance framework applies, use this table to determine the required redaction action for each data category.
+
+| Data category | GDPR | PCI DSS | HIPAA |
+|---------------|------|---------|-------|
+| User identifiers (email, name) | Delete or hash with HMAC | Not required unless tied to cardholder | Delete or hash if part of PHI |
+| Credit card numbers (PAN) | Delete if not needed | Mask: show first 6 and last 4 digits only | Not applicable |
+| CVV / PIN | Delete | Never store, not even masked | Not applicable |
+| Health records / patient IDs | Delete if not needed for purpose | Not applicable | Delete or hash; retain only de-identified data |
+| IP addresses | Truncate or delete (considered personal data) | Not required | Anonymize if part of PHI |
+| Government identifiers (SSN, passport) | Delete | Not applicable | Delete or hash |
+
+Apply the strictest applicable rule when multiple frameworks overlap.
+For example, if both GDPR and PCI DSS apply, delete credit card numbers entirely rather than masking them.
+
+Collector-side enforcement for these rules uses OTTL processors — see the [otel-ottl skill](../../otel-ottl/SKILL.md#redact-sensitive-data) for configuration patterns.
 
 ## References
 

--- a/skills/otel-ottl/SKILL.md
+++ b/skills/otel-ottl/SKILL.md
@@ -508,6 +508,12 @@ Editors modify telemetry data in-place. They are lowercase.
 | `URL` | `URL(url_string)` | Parses URL into components (scheme, host, path, etc.) |
 | `UserAgent` | `UserAgent(value)` | Parses user-agent string into map (name, version, OS) |
 
+## Rules
+
+| Rule | Description |
+|------|-------------|
+| [recipes](./rules/recipes.md) | End-to-end OTTL recipes — PCI compliance, multi-tenant routing, cache patterns, performance |
+
 ## References
 
 - [OTTL Guide](https://www.dash0.com/guides/opentelemetry-transformation-language-ottl)

--- a/skills/otel-ottl/rules/recipes.md
+++ b/skills/otel-ottl/rules/recipes.md
@@ -1,0 +1,237 @@
+---
+title: "OTTL recipes"
+impact: HIGH
+tags:
+  - ottl
+  - recipes
+  - pci
+  - multi-tenant
+  - performance
+---
+
+# OTTL recipes
+
+End-to-end Collector configurations that solve common production problems using OTTL.
+Each recipe is a self-contained pipeline fragment you can add to an existing Collector configuration.
+
+For OTTL syntax and function reference, see the [main OTTL guide](../SKILL.md).
+
+## PCI compliance pipeline
+
+Payment-processing services must not store cardholder data in telemetry.
+This 4-stage pipeline strips PAN, CVV, and related attributes from both traces and logs.
+
+```yaml
+processors:
+  # Stage 1: Delete known sensitive attribute keys
+  transform/pci-delete:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - delete_matching_keys(span.attributes, "(?i).*(card_number|pan|cvv|pin|card\\.number).*")
+    log_statements:
+      - context: log
+        statements:
+          - delete_matching_keys(log.attributes, "(?i).*(card_number|pan|cvv|pin|card\\.number).*")
+
+  # Stage 2: Mask card numbers embedded in log bodies (keep first 6 and last 4)
+  transform/pci-mask-bodies:
+    error_mode: ignore
+    log_statements:
+      - context: log
+        statements:
+          - replace_pattern(log.body["string"], "\\b(\\d{4})[- ]?\\d{4}[- ]?\\d{4}[- ]?(\\d{4})\\b", "\\1-****-****-\\2")
+
+  # Stage 3: Mask card numbers in span attributes (e.g., db.query.text)
+  transform/pci-mask-spans:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - replace_pattern(span.attributes["db.query.text"], "\\b\\d{4}[- ]?\\d{4}[- ]?\\d{4}[- ]?\\d{4}\\b", "****-****-****-****") where span.attributes["db.query.text"] != nil
+
+  # Stage 4: Drop logs that contain private key material
+  filter/pci-drop-keys:
+    error_mode: ignore
+    logs:
+      log_record:
+        - 'IsMatch(log.body["string"], "-----BEGIN (RSA |EC )?PRIVATE KEY-----")'
+
+service:
+  pipelines:
+    traces:
+      processors: [memory_limiter, transform/pci-delete, transform/pci-mask-spans, batch]
+    logs:
+      processors: [memory_limiter, transform/pci-delete, transform/pci-mask-bodies, filter/pci-drop-keys, batch]
+```
+
+Place the PCI processors after `memory_limiter` and before `batch`.
+The `error_mode: ignore` setting ensures that a malformed field does not halt the pipeline — the statement is skipped and processing continues.
+
+## Multi-tenant telemetry isolation
+
+Route telemetry from different tenants to separate backend pipelines.
+This is useful when tenants have different retention policies, export endpoints, or data-residency requirements.
+
+```yaml
+connectors:
+  routing/tenant:
+    default_pipelines: [traces/default]
+    error_mode: ignore
+    table:
+      - statement: route() where resource.attributes["tenant.id"] == "acme"
+        pipelines: [traces/acme]
+      - statement: route() where resource.attributes["tenant.id"] == "globex"
+        pipelines: [traces/globex]
+
+exporters:
+  otlp/default:
+    endpoint: https://default-backend.example.com:4317
+  otlp/acme:
+    endpoint: https://acme-backend.example.com:4317
+  otlp/globex:
+    endpoint: https://globex-backend.example.com:4317
+
+service:
+  pipelines:
+    traces/ingress:
+      receivers: [otlp]
+      processors: [memory_limiter]
+      exporters: [routing/tenant]
+    traces/default:
+      receivers: [routing/tenant]
+      processors: [batch]
+      exporters: [otlp/default]
+    traces/acme:
+      receivers: [routing/tenant]
+      processors: [batch]
+      exporters: [otlp/acme]
+    traces/globex:
+      receivers: [routing/tenant]
+      processors: [batch]
+      exporters: [otlp/globex]
+```
+
+The routing connector evaluates OTTL conditions on each trace and forwards it to the matching pipeline.
+Telemetry that matches no condition goes to `default_pipelines`.
+
+To add a new tenant, add a row to the `table` and a corresponding pipeline and exporter.
+The application must set `tenant.id` as a resource attribute — see the [resources rule](../../otel-instrumentation/rules/resources.md) for how to configure resource attributes in the SDK.
+
+## Multi-step transformation with cache
+
+Some transformations require intermediate values that do not map to a single OTTL statement.
+Use the `cache` map (a per-record scratch pad) to store intermediate results across statements within the same context block.
+
+```yaml
+processors:
+  transform/parse-user-agent:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          # Step 1: Parse user-agent header into a map
+          - set(cache["ua"], UserAgent(span.attributes["http.request.header.user-agent"])) where span.attributes["http.request.header.user-agent"] != nil
+          # Step 2: Extract fields from the parsed map
+          - set(span.attributes["browser.name"], cache["ua"]["name"]) where cache["ua"] != nil
+          - set(span.attributes["browser.version"], cache["ua"]["version"]) where cache["ua"] != nil
+          - set(span.attributes["os.name"], cache["ua"]["os"]) where cache["ua"] != nil
+          # Step 3: Remove the raw header (high cardinality)
+          - delete_key(span.attributes, "http.request.header.user-agent") where cache["ua"] != nil
+```
+
+The `cache` map exists only for the duration of a single telemetry record.
+It is not shared between records and does not persist across batches.
+
+Another common use — parse a URL and set attributes from its components:
+
+```yaml
+processors:
+  transform/parse-url:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - set(cache["url"], URL(span.attributes["url.full"])) where span.attributes["url.full"] != nil
+          - set(span.attributes["url.scheme"], cache["url"]["scheme"]) where cache["url"] != nil
+          - set(span.attributes["url.path"], cache["url"]["path"]) where cache["url"] != nil
+          - set(span.attributes["server.address"], cache["url"]["host"]) where cache["url"] != nil
+```
+
+## Service-specific redaction
+
+Apply stricter redaction rules to services that handle sensitive data (e.g., payment services) while keeping standard redaction for other services.
+
+```yaml
+processors:
+  # Strict: remove all user/customer/payment attributes from payment services
+  transform/redact-payment:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - delete_matching_keys(span.attributes, "(?i).*(user|customer|payment|card).*") where resource.attributes["service.name"] == "payment-service"
+
+  # Standard: redact auth headers everywhere
+  transform/redact-standard:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - set(span.attributes["http.request.header.authorization"], "REDACTED") where span.attributes["http.request.header.authorization"] != nil
+          - set(span.attributes["http.request.header.cookie"], "REDACTED") where span.attributes["http.request.header.cookie"] != nil
+          - set(span.attributes["http.response.header.set-cookie"], "REDACTED") where span.attributes["http.response.header.set-cookie"] != nil
+
+service:
+  pipelines:
+    traces:
+      processors: [memory_limiter, transform/redact-payment, transform/redact-standard, batch]
+```
+
+Order matters: place the stricter processor before the standard one so the payment service attributes are deleted before the standard processor tries to redact them individually.
+
+## Performance anti-patterns
+
+### Missing `where` guards
+
+Every OTTL statement is evaluated for every telemetry record in the pipeline.
+Statements that call expensive functions (regex, parsing, hashing) without a `where` clause waste CPU on records that do not match.
+
+```yaml
+# BAD: SHA256 runs on every span, even those without user.email
+- set(span.attributes["user.email"], SHA256(span.attributes["user.email"]))
+
+# GOOD: only hash when the attribute exists
+- set(span.attributes["user.email"], SHA256(span.attributes["user.email"])) where span.attributes["user.email"] != nil
+```
+
+### Broad regex on large fields
+
+Avoid running complex regex patterns against unbounded fields like `log.body` or `db.query.text` without first checking that the field is present and reasonably sized.
+
+```yaml
+# BAD: regex on every log body regardless of content
+- replace_pattern(log.body["string"], "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b", "****@****.***")
+
+# GOOD: only apply to logs from services known to emit user-facing data
+- replace_pattern(log.body["string"], "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b", "****@****.***") where resource.attributes["service.name"] == "web-api"
+```
+
+### Ordering cheap checks before expensive ones
+
+When multiple conditions apply, place cheap attribute-existence checks in the `where` clause before expensive function calls.
+OTTL evaluates `where` conditions left-to-right and short-circuits on the first `false`.
+
+```yaml
+# GOOD: nil check (cheap) runs before IsMatch (regex, expensive)
+- set(span.attributes["http.route"], "/{id}") where span.attributes["http.route"] != nil and IsMatch(span.attributes["http.route"], "/users/\\d+")
+```
+
+## References
+
+- [OTTL main guide](../SKILL.md)
+- [Transform processor documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor)
+- [Routing connector documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/routingconnector)
+- [Filter processor documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor)
+- [Sensitive data — application-level redaction](../../otel-instrumentation/rules/sensitive-data.md)


### PR DESCRIPTION
## Summary

Ports three categories of content inspired by [henrikrexed/observability-agent-skills](https://github.com/henrikrexed/observability-agent-skills) and [henrikrexed/bmad-observability-agent](https://github.com/henrikrexed/bmad-observability-agent):

- **`otel-instrumentation/rules/sensitive-data.md`** — Enhanced with multi-language SDK-level redaction patterns (Python `SpanProcessor`, Java `DbQuerySanitizer`, Go URL path parameterization, Python HMAC hashing), log body regex sanitization, redaction test patterns using `InMemorySpanExporter`, and a compliance quick-reference table (GDPR, PCI DSS, HIPAA)
- **`otel-collector/rules/custom-builds.md`** *(new)* — Guide for building custom Collector distributions with OCB: manifest structure, version alignment, container images, multi-arch builds, CI pipeline, and common issues
- **`otel-ottl/rules/recipes.md`** *(new)* — End-to-end OTTL recipes for PCI compliance pipelines, multi-tenant routing via the routing connector, cache/temp-map patterns for multi-step transforms, service-specific redaction, and performance anti-patterns

## Test plan

- [ ] Verify all internal cross-references resolve correctly (e.g., links from sensitive-data.md to otel-ottl, from recipes.md to otel-instrumentation)
- [ ] Verify new rule files appear in their respective SKILL.md tables
- [ ] Review code examples for correctness (Python SpanProcessor API, Java regex patterns, OTTL syntax, OCB manifest format)
- [ ] Confirm prose follows CLAUDE.md rules (one sentence per line, sentence case headers, Oxford comma, no emojis)

https://claude.ai/code/session_01M7RhPJn4mxeuukYcYWwuWB