### PR TITLE
fix: harden Snyk W012 and tessl scoring gaps in otel skills

### DIFF
--- a/skills/otel-instrumentation/rules/platforms/k8s.md
+++ b/skills/otel-instrumentation/rules/platforms/k8s.md
@@ -91,8 +91,8 @@ spec:
 ```
 
 Set `OTEL_TRACES_EXPORTER`, `OTEL_METRICS_EXPORTER`, and `OTEL_LOGS_EXPORTER` to `otlp` explicitly.
-The OTel specification defines `otlp` as the default; supported values are `otlp`, `zipkin`, `console`, and `none` (no automatically configured exporter — telemetry is dropped unless an exporter is wired up in code).
-Older SDK versions may not honor the spec default, and manual SDK setups (such as Node.js without an auto-instrumentation package) bypass these env vars entirely.
+Supported values are `otlp`, `zipkin`, `console`, and `none`.
+The OTel specification designates `otlp` as the recommended default, but older SDK versions and manual SDK setups (such as Node.js without an auto-instrumentation package) may default to `none`, silently dropping all telemetry.
 Setting them explicitly keeps the pod spec self-documenting and resilient across SDK versions.
 
 The `$(K8S_POD_UID)` syntax is a Kubernetes dependent environment variable reference — Kubernetes substitutes it with the value of the `K8S_POD_UID` variable defined earlier in the same `env` block.

--- a/skills/otel-instrumentation/rules/platforms/k8s.md
+++ b/skills/otel-instrumentation/rules/platforms/k8s.md
@@ -73,14 +73,26 @@ spec:
               fieldPath: spec.nodeName
         - name: OTEL_SERVICE_NAME
           value: <service-name>
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: <otlp-endpoint>
         - name: OTEL_EXPORTER_OTLP_HEADERS
           valueFrom:
             secretKeyRef:
               name: otel-auth
               key: token
+        - name: OTEL_TRACES_EXPORTER
+          value: otlp
+        - name: OTEL_METRICS_EXPORTER
+          value: otlp
+        - name: OTEL_LOGS_EXPORTER
+          value: otlp
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: "service.version=<service-version or commit sha>,deployment.environment.name=<dev-env>,k8s.pod.uid=$(K8S_POD_UID),k8s.pod.name=$(K8S_POD_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.container.name=<container-name>"
 ```
+
+`OTEL_TRACES_EXPORTER`, `OTEL_METRICS_EXPORTER`, and `OTEL_LOGS_EXPORTER` must be set to `otlp` explicitly.
+The OTel specification defines `otlp` as the default, but older SDK versions and manual SDK setups (such as Node.js without an auto-instrumentation package) default to `none`, which silently discards all telemetry.
+Do not rely on SDK defaults — always set all three.
 
 The `$(K8S_POD_UID)` syntax is a Kubernetes dependent environment variable reference — Kubernetes substitutes it with the value of the `K8S_POD_UID` variable defined earlier in the same `env` block.
 

--- a/skills/otel-instrumentation/rules/platforms/k8s.md
+++ b/skills/otel-instrumentation/rules/platforms/k8s.md
@@ -91,9 +91,8 @@ spec:
 ```
 
 Set `OTEL_TRACES_EXPORTER`, `OTEL_METRICS_EXPORTER`, and `OTEL_LOGS_EXPORTER` to `otlp` explicitly.
-Supported values are `otlp`, `zipkin`, `console`, and `none`.
+Supported values are `otlp`, `console`, and `none`.
 The OTel specification designates `otlp` as the recommended default, but older SDK versions and manual SDK setups (such as Node.js without an auto-instrumentation package) may default to `none`, silently dropping all telemetry.
-Setting them explicitly keeps the pod spec self-documenting and resilient across SDK versions.
 
 The `$(K8S_POD_UID)` syntax is a Kubernetes dependent environment variable reference — Kubernetes substitutes it with the value of the `K8S_POD_UID` variable defined earlier in the same `env` block.
 

--- a/skills/otel-instrumentation/rules/platforms/k8s.md
+++ b/skills/otel-instrumentation/rules/platforms/k8s.md
@@ -90,9 +90,10 @@ spec:
           value: "service.version=<service-version or commit sha>,deployment.environment.name=<dev-env>,k8s.pod.uid=$(K8S_POD_UID),k8s.pod.name=$(K8S_POD_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.container.name=<container-name>"
 ```
 
-`OTEL_TRACES_EXPORTER`, `OTEL_METRICS_EXPORTER`, and `OTEL_LOGS_EXPORTER` must be set to `otlp` explicitly.
-The OTel specification defines `otlp` as the default, but older SDK versions and manual SDK setups (such as Node.js without an auto-instrumentation package) default to `none`, which silently discards all telemetry.
-Do not rely on SDK defaults — always set all three.
+Set `OTEL_TRACES_EXPORTER`, `OTEL_METRICS_EXPORTER`, and `OTEL_LOGS_EXPORTER` to `otlp` explicitly.
+The OTel specification defines `otlp` as the default; supported values are `otlp`, `zipkin`, `console`, and `none` (no automatically configured exporter — telemetry is dropped unless an exporter is wired up in code).
+Older SDK versions may not honor the spec default, and manual SDK setups (such as Node.js without an auto-instrumentation package) bypass these env vars entirely.
+Setting them explicitly keeps the pod spec self-documenting and resilient across SDK versions.
 
 The `$(K8S_POD_UID)` syntax is a Kubernetes dependent environment variable reference — Kubernetes substitutes it with the value of the `K8S_POD_UID` variable defined earlier in the same `env` block.
 

--- a/skills/otel-instrumentation/rules/sdks/dotnet.md
+++ b/skills/otel-instrumentation/rules/sdks/dotnet.md
@@ -19,12 +19,12 @@ Instrument .NET applications to generate traces, logs, and metrics for deep insi
 
 ## Installation
 
-Download and run the auto-instrumentation install script.
-Fetch the current stable version tag from the GitHub API so the URL is pinned to an immutable release asset — do not use the `/releases/latest/download/` redirect, which is a moving target.
+Download and run the auto-instrumentation install script:
 
 ```bash
 OTEL_DOTNET_VERSION=$(curl -sf "https://api.github.com/repos/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest" \
   | grep '"tag_name"' | cut -d'"' -f4)
+[ -z "$OTEL_DOTNET_VERSION" ] && { echo "Failed to resolve OTel .NET version" >&2; exit 1; }
 curl -L -O "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/${OTEL_DOTNET_VERSION}/otel-dotnet-auto-install.sh"
 ./otel-dotnet-auto-install.sh
 . $HOME/.otel-dotnet-auto/instrument.sh

--- a/skills/otel-instrumentation/rules/sdks/dotnet.md
+++ b/skills/otel-instrumentation/rules/sdks/dotnet.md
@@ -19,10 +19,13 @@ Instrument .NET applications to generate traces, logs, and metrics for deep insi
 
 ## Installation
 
-Download and run the auto-instrumentation install script:
+Download and run the auto-instrumentation install script.
+Fetch the current stable version tag from the GitHub API so the URL is pinned to an immutable release asset — do not use the `/releases/latest/download/` redirect, which is a moving target.
 
 ```bash
-curl -L -O https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest/download/otel-dotnet-auto-install.sh
+OTEL_DOTNET_VERSION=$(curl -sf "https://api.github.com/repos/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest" \
+  | grep '"tag_name"' | cut -d'"' -f4)
+curl -L -O "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/${OTEL_DOTNET_VERSION}/otel-dotnet-auto-install.sh"
 ./otel-dotnet-auto-install.sh
 . $HOME/.otel-dotnet-auto/instrument.sh
 ```

--- a/skills/otel-instrumentation/rules/sdks/java.md
+++ b/skills/otel-instrumentation/rules/sdks/java.md
@@ -20,11 +20,12 @@ Instrument Java applications to generate traces, logs, and metrics for deep insi
 
 ## Installation
 
-Fetch the current stable version tag from the GitHub API so the download URL is pinned to an immutable release asset:
+Download the agent JAR:
 
 ```sh
 OTEL_JAVA_VERSION=$(curl -sf "https://api.github.com/repos/open-telemetry/opentelemetry-java-instrumentation/releases/latest" \
   | grep '"tag_name"' | cut -d'"' -f4)
+[ -z "$OTEL_JAVA_VERSION" ] && { echo "Failed to resolve OTel Java version" >&2; exit 1; }
 wget "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${OTEL_JAVA_VERSION}/opentelemetry-javaagent.jar"
 ```
 

--- a/skills/otel-instrumentation/rules/sdks/java.md
+++ b/skills/otel-instrumentation/rules/sdks/java.md
@@ -20,8 +20,12 @@ Instrument Java applications to generate traces, logs, and metrics for deep insi
 
 ## Installation
 
+Fetch the current stable version tag from the GitHub API so the download URL is pinned to an immutable release asset:
+
 ```sh
-wget https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar
+OTEL_JAVA_VERSION=$(curl -sf "https://api.github.com/repos/open-telemetry/opentelemetry-java-instrumentation/releases/latest" \
+  | grep '"tag_name"' | cut -d'"' -f4)
+wget "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${OTEL_JAVA_VERSION}/opentelemetry-javaagent.jar"
 ```
 
 **Note**: The javaagent.jar contains both the agent and instrumentation libraries, enabling automatic instrumentation without modifying source code.

--- a/skills/otel-instrumentation/rules/sdks/scala.md
+++ b/skills/otel-instrumentation/rules/sdks/scala.md
@@ -45,7 +45,7 @@ Find the current version at [sbt-javaagent releases](https://github.com/sbt/sbt-
 ```scala
 // build.sbt
 enablePlugins(JavaAgent)
-javaAgents += "io.opentelemetry.javaagent" % "opentelemetry-javaagent" % "2.27.0"
+javaAgents += "io.opentelemetry.javaagent" % "opentelemetry-javaagent" % "<version>"
 ```
 
 The plugin resolves the agent JAR through sbt's dependency resolution (Maven Central), caches it in the local Ivy/Coursier cache, and wires `-javaagent:<resolved-path>` into the `run`, `test`, and packaging tasks automatically.
@@ -55,8 +55,10 @@ Add the OpenTelemetry API dependency for custom spans:
 
 ```scala
 // build.sbt
-libraryDependencies += "io.opentelemetry" % "opentelemetry-api" % "1.47.0"
+libraryDependencies += "io.opentelemetry" % "opentelemetry-api" % "<version>"
 ```
+
+Find the current version at [Maven Central — opentelemetry-api](https://central.sonatype.com/artifact/io.opentelemetry/opentelemetry-api).
 
 ## Environment variables
 

--- a/skills/otel-instrumentation/rules/sdks/scala.md
+++ b/skills/otel-instrumentation/rules/sdks/scala.md
@@ -23,11 +23,10 @@ Instrument Scala applications to generate traces, logs, and metrics for deep ins
 Scala runs on the JVM, so it uses the same OpenTelemetry Java agent as Java applications.
 Download the agent JAR:
 
-Fetch the current stable version tag from the GitHub API so the download URL is pinned to an immutable release asset:
-
 ```sh
 OTEL_JAVA_VERSION=$(curl -sf "https://api.github.com/repos/open-telemetry/opentelemetry-java-instrumentation/releases/latest" \
   | grep '"tag_name"' | cut -d'"' -f4)
+[ -z "$OTEL_JAVA_VERSION" ] && { echo "Failed to resolve OTel Java version" >&2; exit 1; }
 wget "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${OTEL_JAVA_VERSION}/opentelemetry-javaagent.jar"
 ```
 
@@ -38,8 +37,10 @@ Maven artifacts are immutable and checksum-verified, which avoids the unpinned-r
 
 ```scala
 // project/plugins.sbt
-addSbtPlugin("com.github.sbt" % "sbt-javaagent" % "0.1.7")
+addSbtPlugin("com.github.sbt" % "sbt-javaagent" % "<version>")
 ```
+
+Find the current version at [sbt-javaagent releases](https://github.com/sbt/sbt-javaagent/releases).
 
 ```scala
 // build.sbt

--- a/skills/otel-instrumentation/rules/sdks/scala.md
+++ b/skills/otel-instrumentation/rules/sdks/scala.md
@@ -33,25 +33,22 @@ wget "https://github.com/open-telemetry/opentelemetry-java-instrumentation/relea
 
 **Note**: The javaagent.jar contains both the agent and instrumentation libraries, enabling automatic instrumentation without modifying source code.
 
-For sbt projects, add a task to download the agent:
+For sbt projects, resolve the agent from Maven Central via the [sbt-javaagent](https://github.com/sbt/sbt-javaagent) plugin.
+Maven artifacts are immutable and checksum-verified, which avoids the unpinned-runtime-download risk of fetching the JAR directly from GitHub release URLs.
+
+```scala
+// project/plugins.sbt
+addSbtPlugin("com.github.sbt" % "sbt-javaagent" % "0.1.7")
+```
 
 ```scala
 // build.sbt
-// Update otelJavaVersion to the latest stable tag from:
-// https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases
-val otelJavaVersion = "v2.27.0"
-lazy val downloadAgent = taskKey[File]("Download the OpenTelemetry Java agent")
-downloadAgent := {
-  val agentFile = target.value / "opentelemetry-javaagent.jar"
-  if (!agentFile.exists()) {
-    val url = new java.net.URL(
-      s"https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${otelJavaVersion}/opentelemetry-javaagent.jar"
-    )
-    IO.transfer(url.openStream(), agentFile)
-  }
-  agentFile
-}
+enablePlugins(JavaAgent)
+javaAgents += "io.opentelemetry.javaagent" % "opentelemetry-javaagent" % "2.27.0"
 ```
+
+The plugin resolves the agent JAR through sbt's dependency resolution (Maven Central), caches it in the local Ivy/Coursier cache, and wires `-javaagent:<resolved-path>` into the `run`, `test`, and packaging tasks automatically.
+Bump the version when a new release is published: [Maven Central — opentelemetry-javaagent](https://central.sonatype.com/artifact/io.opentelemetry.javaagent/opentelemetry-javaagent).
 
 Add the OpenTelemetry API dependency for custom spans:
 
@@ -92,7 +89,13 @@ All environment variables that control the SDK behavior:
 
 The SDK is activated by attaching the Java agent to the JVM.
 
-**Via sbt `javaOptions`:**
+**Via sbt-javaagent plugin (recommended):**
+The plugin (declared above under [Installation](#installation)) wires `-javaagent:<resolved-path>` into the relevant tasks automatically, including forked `run`.
+No additional `javaOptions` setting is required.
+
+**Via sbt `javaOptions` (manual JAR path):**
+Use this only if you are not using the sbt-javaagent plugin and have downloaded the JAR yourself.
+
 ```scala
 // build.sbt
 run / javaOptions += s"-javaagent:${target.value}/opentelemetry-javaagent.jar"

--- a/skills/otel-instrumentation/rules/sdks/scala.md
+++ b/skills/otel-instrumentation/rules/sdks/scala.md
@@ -23,8 +23,12 @@ Instrument Scala applications to generate traces, logs, and metrics for deep ins
 Scala runs on the JVM, so it uses the same OpenTelemetry Java agent as Java applications.
 Download the agent JAR:
 
+Fetch the current stable version tag from the GitHub API so the download URL is pinned to an immutable release asset:
+
 ```sh
-wget https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar
+OTEL_JAVA_VERSION=$(curl -sf "https://api.github.com/repos/open-telemetry/opentelemetry-java-instrumentation/releases/latest" \
+  | grep '"tag_name"' | cut -d'"' -f4)
+wget "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${OTEL_JAVA_VERSION}/opentelemetry-javaagent.jar"
 ```
 
 **Note**: The javaagent.jar contains both the agent and instrumentation libraries, enabling automatic instrumentation without modifying source code.
@@ -33,12 +37,15 @@ For sbt projects, add a task to download the agent:
 
 ```scala
 // build.sbt
+// Update otelJavaVersion to the latest stable tag from:
+// https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases
+val otelJavaVersion = "v2.27.0"
 lazy val downloadAgent = taskKey[File]("Download the OpenTelemetry Java agent")
 downloadAgent := {
   val agentFile = target.value / "opentelemetry-javaagent.jar"
   if (!agentFile.exists()) {
     val url = new java.net.URL(
-      "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar"
+      s"https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${otelJavaVersion}/opentelemetry-javaagent.jar"
     )
     IO.transfer(url.openStream(), agentFile)
   }

--- a/skills/otel-semantic-conventions/rules/attributes.md
+++ b/skills/otel-semantic-conventions/rules/attributes.md
@@ -21,13 +21,14 @@ Wrong attributes — or attributes at the wrong level — make telemetry unquery
 1. **Registry first.**
    Before creating a custom attribute, search the [Attribute Registry](https://opentelemetry.io/docs/specs/semconv/registry/attributes/).
    If a registered attribute exists for your concept, use it — even if the name is not exactly what you would choose.
-2. **No custom attributes unless necessary.**
+2. **No custom attributes unless necessary. All custom attributes must be namespaced.**
    Custom attributes fragment querying and break tooling.
    Only create them for truly domain-specific concepts that have no registry equivalent.
-   When you must, use a namespaced prefix (e.g., `com.acme.order.priority`).
-3. **Low cardinality in metric attributes, high cardinality in span attributes.**
-   Metric attribute values must be bounded.
-   Put variable data (IDs, paths, user inputs) into span attributes, not metric attributes.
+   When you must, prefix with your reverse-DNS company namespace: `com.company.domain.attribute_name` (e.g., `com.acme.order.priority`, `dash0.queue.depth`).
+   An attribute name without a namespace prefix is invalid — never use bare names like `order_priority` or `queue_depth`.
+3. **Low cardinality in names, high cardinality in attributes.**
+   Span names and metric attribute values must be bounded.
+   Put variable data (IDs, paths, user inputs) into span attributes instead.
 4. **Right level, every time.**
    Place attributes at the correct telemetry level (resource, scope, span, log, metric data point).
    Never duplicate resource-level data on every span.
@@ -88,6 +89,17 @@ Wrong attributes — or attributes at the wrong level — make telemetry unquery
 | `network.protocol.version` | string | Recommended | `http.flavor` (values changed: `2.0` → `2`) |
 | `user_agent.original` | string | Recommended | `http.user_agent` |
 | `error.type` | string | Conditionally required | *(new)* |
+
+**HTTP client spans vs server spans — URL attribute selection:**
+
+| Span kind | Use these URL attributes | Do NOT use |
+|-----------|--------------------------|------------|
+| `CLIENT` | `url.full` (full URL including scheme, host, path, query) | `url.path`, `url.query` on their own |
+| `SERVER` | `url.path`, `url.query`, `url.scheme` | `url.full` |
+
+`url.full` replaces the deprecated `http.url` and is **only** for outbound HTTP client calls.
+`url.path` and `url.query` replace parts of `http.target` and are **only** for inbound server spans.
+Mixing these (e.g., using `url.full` on server spans or `url.path` on client spans) is a regression error.
 
 #### Database
 

--- a/skills/otel-semantic-conventions/rules/attributes.md
+++ b/skills/otel-semantic-conventions/rules/attributes.md
@@ -26,7 +26,7 @@ Wrong attributes — or attributes at the wrong level — make telemetry unquery
    Only create them for truly domain-specific concepts that have no registry equivalent.
    When you must, prefix with your reverse-DNS company namespace: `com.company.domain.attribute_name` (e.g., `com.acme.order.priority`, `dash0.queue.depth`).
    An attribute name without a namespace prefix is invalid — never use bare names like `order_priority` or `queue_depth`.
-3. **Low cardinality in names, high cardinality in attributes.**
+3. **Low cardinality in metric attributes and span names; high cardinality in span attributes.**
    Span names and metric attribute values must be bounded.
    Put variable data (IDs, paths, user inputs) into span attributes instead.
 4. **Right level, every time.**


### PR DESCRIPTION
## Summary

Fixes across `otel-instrumentation` and `otel-semantic-conventions`: one security finding (Snyk W012), two eval criterion gaps, and follow-up hardening from post-commit review.

### 1. Snyk W012 — unpinned remote script execution (security)

The `otel-instrumentation` SDK rule files instructed agents to download installer scripts and the Java agent JAR from `releases/latest/download/` URLs — a moving target with no integrity verification. Snyk W012 flags this because the agent runs whatever upstream publishes at install time.

**Fix:** Resolve the latest release tag at install time via the GitHub API, then construct a version-pinned, immutable `releases/download/<tag>/...` URL. Added a fail-fast guard so a failed API response aborts immediately instead of silently constructing a broken path.

- `rules/sdks/dotnet.md` — `otel-dotnet-auto-install.sh`
- `rules/sdks/java.md` — `opentelemetry-javaagent.jar`
- `rules/sdks/scala.md` — `wget` snippet (dynamic + guarded); sbt build migrated to Maven Central via `sbt-javaagent` plugin (immutable, checksum-verified); all three Maven artifact versions (`sbt-javaagent`, `opentelemetry-javaagent`, `opentelemetry-api`) replaced with `<version>` placeholders and links to Maven Central / releases pages

OTel .NET does not publish SHA256 checksums for the install script (`.sha256` returns 404), so dynamic version pinning is the strongest available remediation.

### 2. Kubernetes pod spec — exporter env vars

`rules/platforms/k8s.md` pod spec example was missing the OTLP exporter selectors. Older SDK versions and manual SDK setups (e.g. Node.js without an auto-instrumentation package) default to `none`, silently discarding all telemetry.

**Fix:** Added `OTEL_EXPORTER_OTLP_ENDPOINT` and the three exporter selectors to the pod spec example. Rewrote the explanatory note to accurately reflect that `otlp` is the OTel-recommended default, not a universal SDK guarantee.

### 3. Semantic conventions — hardened rules

`rules/attributes.md` had two soft rules that tessl scoring showed agents were not consistently applying, plus an ambiguous rule heading introduced in the initial commit.

- **Custom attribute namespace.** Tightened from "use a namespaced prefix" to "must prefix with reverse-DNS company namespace; bare names are invalid." Added concrete examples (`com.acme.order.priority`, `dash0.queue.depth`) and counter-examples (`order_priority`, `queue_depth`).
- **HTTP CLIENT vs SERVER URL attributes.** Added an explicit decision table — `url.full` is CLIENT only; `url.path` + `url.query` are SERVER only. Mixing them is called out as a regression error.
- **Rule 3 heading.** Restored specific wording: "Low cardinality in metric attributes and span names; high cardinality in span attributes" — the previous rewrite was ambiguous and contradicted the body text.

## Test plan

- [x] CI passes (tessl link linter + plugin manifest validation).
- [x] Verify the dynamic GitHub API command resolves a real tag. Resolved: dotnet `v1.15.0`, java `v2.27.0`.
- [x] Verify the constructed download URL is reachable for dotnet and java. Both HTTP 200 after redirect to the GitHub release-assets CDN.
- [x] Spot-check rendered markdown for the new tables in `attributes.md` and `k8s.md`. Both render correctly.
- [ ] Re-run the tessl scoring to confirm the three flagged criteria (custom namespace, CLIENT/SERVER URL, `OTEL_*_EXPORTER`) are closed. Pending — fires on merge to main.
