### PR TITLE
chore: validate tessl publish source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
     name: Create GitHub release
     needs: validate
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -93,7 +96,7 @@ jobs:
             git commit -m "chore: update plugin manifests for ${TAG}"
             git push origin HEAD
           fi
- 
+
       - name: Update CHANGELOG.md
         env:
           TAG: ${{ steps.version.outputs.tag }}


### PR DESCRIPTION
The `tessl` CLI (invoked here with `tessl tile publish`) supports using OIDC tokens to validate that the plugin was published from GitHub and subsequently to link it any other previously indexed skills against the same repo.

While this was documented in the older `tessl/publish` action, it was not mentioned in the `tessl/setup-tessl` action (rectified in https://github.com/tesslio/setup-tessl/pull/10). This patch allows the `release` workflow to access an OIDC token by updating its permissions.