### PR TITLE
Add eval scenarios for otel skills

### DIFF
--- a/evals/otel-collector-scenario-1/criteria.json
+++ b/evals/otel-collector-scenario-1/criteria.json
@@ -1,0 +1,66 @@
+{
+  "context": "Tests whether the agent correctly configures a production-grade OpenTelemetry Collector YAML, using the appropriate processor ordering, persistent queue strategy, authentication pattern, and safety settings. The agent is expected to produce a collector-config.yaml that avoids common anti-patterns such as the batch processor and hardcoded credentials.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "memory_limiter first",
+      "description": "The memory_limiter processor appears as the FIRST entry in every pipeline's processors list (before any other processor)",
+      "max_score": 12
+    },
+    {
+      "name": "No batch processor",
+      "description": "The configuration does NOT include a batch processor anywhere (no 'batch:' under processors)",
+      "max_score": 12
+    },
+    {
+      "name": "sending_queue with file_storage",
+      "description": "The OTLP exporter's sending_queue has storage: file_storage (not in-memory queue)",
+      "max_score": 10
+    },
+    {
+      "name": "No hardcoded token",
+      "description": "The auth token is referenced via ${env:...} syntax, NOT hardcoded as a literal string in the Authorization header",
+      "max_score": 8
+    },
+    {
+      "name": "gzip compression",
+      "description": "The OTLP exporter has compression: gzip configured",
+      "max_score": 8
+    },
+    {
+      "name": "No debug exporter",
+      "description": "The debug exporter does NOT appear in any production pipeline's exporters list",
+      "max_score": 8
+    },
+    {
+      "name": "Separate signal pipelines",
+      "description": "The service.pipelines section defines separate pipelines for traces, metrics, AND logs (three distinct pipeline keys)",
+      "max_score": 8
+    },
+    {
+      "name": "health_check extension",
+      "description": "The configuration includes the health_check extension listed under service.extensions",
+      "max_score": 7
+    },
+    {
+      "name": "0.0.0.0 bind address",
+      "description": "The OTLP receiver gRPC and/or HTTP endpoints use 0.0.0.0 (not localhost) as the bind address",
+      "max_score": 7
+    },
+    {
+      "name": "memory_limiter sizing",
+      "description": "The memory_limiter limit_mib value is set to approximately 80% of the stated container memory limit (e.g., for a 512Mi container, limit_mib is between 400-420)",
+      "max_score": 7
+    },
+    {
+      "name": "file_storage extension declared",
+      "description": "A file_storage extension is declared in the extensions section with a directory path, AND it is listed in service.extensions",
+      "max_score": 7
+    },
+    {
+      "name": "All declared components used",
+      "description": "Every receiver, processor, and exporter declared in the config appears in at least one pipeline (no orphaned components)",
+      "max_score": 6
+    }
+  ]
+}

--- a/evals/otel-collector-scenario-1/task.md
+++ b/evals/otel-collector-scenario-1/task.md
@@ -1,0 +1,22 @@
+# Reliable Telemetry Forwarding for a Payments Microservices Platform
+
+## Problem/Feature Description
+
+A fintech company runs a payments platform composed of a dozen microservices. Each service is already instrumented with OpenTelemetry SDKs that export traces, metrics, and logs via OTLP. The platform team has been asked to deploy a centralized OpenTelemetry Collector that aggregates telemetry from all services and forwards it to their Dash0 observability account.
+
+The team has had incidents in the past caused by Collector crashes during deployment peaks — telemetry was lost because buffered data disappeared when the process restarted. They also discovered that a previous config accidentally logged full telemetry payloads to stdout in production, consuming significant disk I/O. The platform team wants a configuration that survives restarts without data loss, does not leak credentials, and is safe to leave running permanently in production.
+
+The Collector will be deployed as a container with a 512 MiB memory limit. It must accept OTLP telemetry from other containers on the same network. The Dash0 OTLP endpoint is `ingress.eu-west-1.aws.dash0.com:4317` and the auth token will be injected as an environment variable named `DASH0_AUTH_TOKEN`.
+
+## Output Specification
+
+Produce a file named `collector-config.yaml` containing a complete, production-ready OpenTelemetry Collector configuration that:
+
+- Accepts OTLP telemetry (gRPC and HTTP) from networked containers
+- Processes and forwards traces, metrics, and logs to Dash0
+- Handles transient backend unavailability without data loss
+- Has appropriate memory safeguards for the 512 MiB container limit
+- Exposes a health check endpoint
+
+Do not include any placeholder tokens or credentials in the configuration file itself.
+

--- a/evals/otel-collector-scenario-2/criteria.json
+++ b/evals/otel-collector-scenario-2/criteria.json
@@ -1,0 +1,61 @@
+{
+  "context": "Tests whether the agent correctly configures Kubernetes metadata enrichment for an OpenTelemetry Collector, including proper k8sattributes pod association order, extraction of both workload name and UID, consistent enrichment across all signal pipelines, correct processor ordering, and cluster-level static attributes via the resource processor.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Enrichment on all pipelines",
+      "description": "Both k8sattributes (or resourcedetection) AND resource processors appear in the processors list of ALL three pipelines: traces, metrics, AND logs — not just one or two",
+      "max_score": 12
+    },
+    {
+      "name": "k8s.pod.uid first in pod_association",
+      "description": "In the k8sattributes pod_association, the entry using 'from: resource_attribute' with name 'k8s.pod.uid' appears BEFORE the 'from: connection' entry",
+      "max_score": 12
+    },
+    {
+      "name": "Workload name and UID extracted",
+      "description": "The k8sattributes extract.metadata list includes BOTH k8s.deployment.name AND k8s.deployment.uid (both name and UID, not just one)",
+      "max_score": 10
+    },
+    {
+      "name": "resourcedetection override false",
+      "description": "The resourcedetection processor has override: false configured (not override: true or missing)",
+      "max_score": 9
+    },
+    {
+      "name": "resource processor for cluster attributes",
+      "description": "A resource processor is configured and sets at least one cluster-level attribute (e.g., k8s.cluster.name) using action: upsert or action: insert",
+      "max_score": 9
+    },
+    {
+      "name": "Processor ordering: enrichment after memory_limiter",
+      "description": "In each pipeline, memory_limiter appears before resourcedetection and/or k8sattributes (enrichment processors come after memory_limiter)",
+      "max_score": 9
+    },
+    {
+      "name": "Processor ordering: resource after enrichment",
+      "description": "In each pipeline, the resource processor (static attributes) appears AFTER resourcedetection and k8sattributes (not before them)",
+      "max_score": 8
+    },
+    {
+      "name": "k8sattributes passthrough: false",
+      "description": "The k8sattributes processor has passthrough: false (appropriate for a Collector that performs the Kubernetes API lookup itself)",
+      "max_score": 7
+    },
+    {
+      "name": "memory_limiter first",
+      "description": "memory_limiter is the first processor in every pipeline's processor list",
+      "max_score": 7
+    },
+    {
+      "name": "k8s.cluster.uid kube-system reference",
+      "description": "The configuration or accompanying documentation/comments references retrieving k8s.cluster.uid from the kube-system namespace (e.g., via kubectl get namespace kube-system -o jsonpath='{.metadata.uid}' or a placeholder comment explaining how to set it)",
+      "max_score": 8
+    },
+    {
+      "name": "No batch processor",
+      "description": "The configuration does NOT include a batch processor in any pipeline",
+      "max_score": 9
+    }
+  ]
+}

--- a/evals/otel-collector-scenario-2/task.md
+++ b/evals/otel-collector-scenario-2/task.md
@@ -1,0 +1,25 @@
+# Kubernetes Telemetry Enrichment for Multi-Cluster Observability
+
+## Problem/Feature Description
+
+A large e-commerce company runs microservices across two Kubernetes clusters: a primary production cluster and a disaster-recovery cluster in a different region. Their platform observability team has deployed OpenTelemetry Collectors on each cluster, but telemetry arriving at their backend is difficult to analyze because it lacks Kubernetes context. Traces, metrics, and logs all arrive without information about which namespace, deployment, or pod they originated from, making it impossible to filter by workload or correlate signals from the same service.
+
+The team has also run into an issue where infrastructure metadata (host names, cloud provider details) was overwriting the `service.name` set by their application SDKs, leaving spans labeled `unknown_service` instead of the intended service identifiers.
+
+They want a single `collector-config.yaml` for the gateway Collector (a Deployment, not a DaemonSet) that solves these problems. The config should:
+
+- Enrich all telemetry signals with Kubernetes metadata including namespace, deployment name and identity, pod name and identity, and node name
+- Tag all telemetry with cluster-level attributes so data from each cluster can be distinguished
+- Avoid overwriting resource attributes already set by application SDKs
+- Work reliably with service-mesh environments (Istio/Linkerd) where connection-IP-based pod matching is unreliable
+
+The cluster runs Istio as a service mesh. The clusters are named `prod-eu-1` and `dr-eu-2`. The unique cluster identifier should be derived from a built-in Kubernetes resource that has a unique UID per cluster.
+
+## Output Specification
+
+Produce a file named `collector-config.yaml` containing a complete OpenTelemetry Collector configuration for the gateway Collector. The configuration must cover all three signal types (traces, metrics, and logs).
+
+Include a file named `notes.md` explaining:
+1. What Kubernetes resource you used to derive the cluster UID and how to retrieve it
+2. Why the pod association strategy is configured the way it is, given the service mesh environment
+

--- a/evals/otel-collector-scenario-3/criteria.json
+++ b/evals/otel-collector-scenario-3/criteria.json
@@ -1,0 +1,61 @@
+{
+  "context": "Tests whether the agent correctly sets up RED metric materialization from traces using the signaltometricsconnector with tail-based sampling, ensuring metrics accuracy by deriving them from all spans before sampling, and using the correct histogram type and connector wiring.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "signaltometrics not spanmetrics",
+      "description": "Uses the signaltometricsconnector (signaltometrics connector type), NOT the spanmetricsconnector (span_metrics or spanmetrics connector type)",
+      "max_score": 12
+    },
+    {
+      "name": "exponential_histogram used",
+      "description": "The signaltometrics connector defines metrics using exponential_histogram (not a histogram with explicit bucket boundaries)",
+      "max_score": 10
+    },
+    {
+      "name": "Connector before sampling in pipeline",
+      "description": "In the traces pipeline, signaltometrics appears in the exporters list BEFORE or alongside the backend OTLP exporter — and the tail_sampling processor runs on the traces pipeline where the connector also exports (not after a separate sampling-only fork)",
+      "max_score": 12
+    },
+    {
+      "name": "Metrics pipeline uses connector as receiver",
+      "description": "A separate metrics pipeline exists with signaltometrics as a receiver (e.g., metrics/red or metrics pipeline with receivers: [signaltometrics])",
+      "max_score": 10
+    },
+    {
+      "name": "Semconv metric names",
+      "description": "At least one of the following metric names appears in the connector definition: http.server.request.duration, http.client.request.duration, rpc.server.call.duration, or rpc.client.call.duration",
+      "max_score": 8
+    },
+    {
+      "name": "Semconv conditions used",
+      "description": "The connector span conditions use SPAN_KIND_SERVER or SPAN_KIND_CLIENT (not simple status-code conditions), matching the semantic convention filter patterns",
+      "max_score": 8
+    },
+    {
+      "name": "service.name in resource attributes",
+      "description": "The connector includes service.name in include_resource_attributes (so generated metrics carry the service identifier)",
+      "max_score": 8
+    },
+    {
+      "name": "AlwaysOn sampler recommendation",
+      "description": "The configuration or accompanying notes.md recommend (or assumes) that application SDKs use AlwaysOn sampling and that sampling only happens in the Collector",
+      "max_score": 6
+    },
+    {
+      "name": "Tail sampling policies include errors and latency",
+      "description": "The tailsamplingprocessor defines at least an error policy (type: status_code with ERROR) AND a latency policy (type: latency), not just probabilistic sampling",
+      "max_score": 8
+    },
+    {
+      "name": "memory_limiter first",
+      "description": "memory_limiter appears as the first processor in every pipeline (traces and metrics pipelines)",
+      "max_score": 9
+    },
+    {
+      "name": "No batch processor",
+      "description": "No batch processor is present in any pipeline",
+      "max_score": 9
+    }
+  ]
+}

--- a/evals/otel-collector-scenario-3/task.md
+++ b/evals/otel-collector-scenario-3/task.md
@@ -1,0 +1,23 @@
+# SLO-Accurate RED Metrics Alongside Trace Volume Reduction
+
+## Problem/Feature Description
+
+A B2B SaaS company's platform engineering team manages a high-traffic API gateway that processes around 2,000 requests per second. Their observability setup exports every trace to their backend, which is generating significant storage costs. The team wants to implement sampling to reduce trace volume by roughly 90%, while retaining all error traces, traces for requests slower than 1 second, and a 10% random baseline of healthy traffic.
+
+The team also runs service-level dashboards and alerts based on request rate, error rate, and duration (RED metrics). They previously tried head sampling but discovered that their dashboards were showing incorrect error rates because sampled traces underrepresented errors. A colleague suggested computing RED metrics from spans before any sampling decision is made.
+
+The platform team needs a gateway Collector configuration that:
+- Implements intelligent, content-aware trace sampling (keeping errors, slow requests, and a baseline of normal traffic)
+- Derives accurate RED metrics from HTTP server spans, using metric names that match standard OpenTelemetry semantic conventions so they can be correlated with SDK-emitted metrics
+- Exports both the (sampled) traces and the derived metrics to Dash0
+
+The Dash0 OTLP endpoint is `ingress.eu-west-1.aws.dash0.com:4317` and the auth token will be injected as an environment variable named `DASH0_AUTH_TOKEN`.
+
+## Output Specification
+
+Produce a file named `collector-config.yaml` containing the gateway Collector configuration.
+
+Also produce a file named `notes.md` that explains:
+1. Why RED metrics must be computed before sampling (not after)
+2. What sampler setting you recommend for the application SDKs, and why
+

--- a/evals/otel-instrumentation-scenario-1/criteria.json
+++ b/evals/otel-instrumentation-scenario-1/criteria.json
@@ -1,0 +1,66 @@
+{
+  "context": "Tests whether an agent correctly configures OpenTelemetry for a Node.js CommonJS Express service, covering SDK activation, exporter configuration, correct HTTP span status mapping, sensitive data handling, exception recording, and trace-log correlation.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Correct SDK activation flag",
+      "description": "Uses --require (not --import) in NODE_OPTIONS to activate auto-instrumentation, matching CommonJS module system",
+      "max_score": 8
+    },
+    {
+      "name": "OTEL_TRACES_EXPORTER set",
+      "description": "Sets OTEL_TRACES_EXPORTER=otlp explicitly (does not rely on default, which silently discards telemetry)",
+      "max_score": 8
+    },
+    {
+      "name": "gRPC protocol configured",
+      "description": "Sets OTEL_EXPORTER_OTLP_PROTOCOL=grpc when the collector endpoint uses port 4317",
+      "max_score": 8
+    },
+    {
+      "name": "4xx SERVER span status",
+      "description": "HTTP 4xx responses on SERVER spans are documented or coded as status UNSET, not ERROR",
+      "max_score": 10
+    },
+    {
+      "name": "5xx SERVER span status",
+      "description": "HTTP 5xx responses on SERVER spans result in status ERROR with a descriptive message containing error class and context",
+      "max_score": 8
+    },
+    {
+      "name": "No span.recordException",
+      "description": "Does NOT call span.recordException(error) for exception recording — uses a structured log record instead",
+      "max_score": 10
+    },
+    {
+      "name": "Exception log trace context",
+      "description": "Exception log records include both trace_id and span_id extracted from the active span context, AND include exception.type, exception.message, exception.stacktrace as structured attributes",
+      "max_score": 8
+    },
+    {
+      "name": "URL query param redaction",
+      "description": "URL attributes (url.full or similar) have query parameters stripped or redacted before being attached to spans",
+      "max_score": 8
+    },
+    {
+      "name": "No PII or credentials in telemetry",
+      "description": "Does NOT attach raw auth headers, passwords, or email addresses directly as span or log attribute values",
+      "max_score": 8
+    },
+    {
+      "name": "Structured logging only",
+      "description": "All log statements use structured key-value pairs; no template-literal string interpolation used as the primary log message",
+      "max_score": 8
+    },
+    {
+      "name": "Trace-log correlation in handlers",
+      "description": "A helper or inline extraction of trace_id and span_id is used to inject trace context into log records emitted inside request handlers",
+      "max_score": 8
+    },
+    {
+      "name": "forceFlush on crash handlers",
+      "description": "Registers uncaughtException and/or unhandledRejection process handlers that flush the tracer provider before calling process.exit",
+      "max_score": 8
+    }
+  ]
+}

--- a/evals/otel-instrumentation-scenario-1/task.md
+++ b/evals/otel-instrumentation-scenario-1/task.md
@@ -1,0 +1,28 @@
+# Payment API Observability Setup
+
+## Problem Description
+
+FinPay Ltd. is launching a payment processing API built with Node.js and Express. The service is a CommonJS application that handles credit card payments on behalf of merchants. Before going to production, the engineering team needs to add OpenTelemetry instrumentation so the operations team can monitor request latency, detect errors, and correlate logs to traces during incidents.
+
+The service already has a basic Express app (`app.js`) and runs behind an OpenTelemetry Collector that listens on gRPC at port 4317. The team wants traces, metrics, and logs all exported via OTLP. The collector endpoint is `http://otel-collector:4317`. Authentication is handled by a pre-existing environment variable `OTEL_AUTH_TOKEN`.
+
+Because FinPay processes credit card payments, the team is especially concerned about accidentally leaking sensitive data (card numbers, auth tokens, user emails) into the telemetry pipeline. Request URLs may contain session tokens as query parameters, and log statements must not expose raw authorization headers or card data.
+
+The codebase contains three HTTP routes that need proper instrumentation:
+- `POST /api/payments` — initiates a payment; may return 400 (invalid request), 402 (insufficient funds), or 500 (processor unavailable)
+- `GET /api/payments/:paymentId` — retrieves a payment record; returns 404 if not found
+- `DELETE /api/payments/:paymentId/cancel` — cancels a pending payment
+
+The team also needs proper error handling so that if the Node.js process crashes unexpectedly, any in-flight telemetry is flushed to the backend before the process exits.
+
+## Output Specification
+
+Produce the following files in your working directory:
+
+1. **`instrumentation.js`** — OpenTelemetry SDK setup and initialization code that can be loaded before the app
+2. **`.env.local`** — Environment variable configuration for running the instrumented service locally
+3. **`payment-handlers.js`** — Example implementation of the three route handlers above, with correct span status handling, exception recording (using structured log records), sensitive data sanitization, and trace-log correlation
+4. **`package.json`** — Package manifest listing the required OTel dependencies and npm scripts to run the instrumented app
+
+The files should be self-consistent and runnable (or near-runnable) without additional input. Placeholder values are acceptable for the OTLP endpoint and auth token where real values are not available.
+

--- a/evals/otel-instrumentation-scenario-2/criteria.json
+++ b/evals/otel-instrumentation-scenario-2/criteria.json
@@ -1,0 +1,66 @@
+{
+  "context": "Tests whether an agent correctly designs and implements custom OpenTelemetry metrics for a Node.js service, covering instrument type selection, UCUM units, naming conventions, cardinality management, and avoiding duplication of auto-instrumented metrics.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Histogram for durations",
+      "description": "Uses a Histogram instrument (not Counter or Gauge) for measuring order/job processing time or any latency distribution",
+      "max_score": 10
+    },
+    {
+      "name": "Counter for monotonic counts",
+      "description": "Uses a Counter (not Gauge or UpDownCounter) for counting completed orders or processed items that only increase",
+      "max_score": 8
+    },
+    {
+      "name": "UpDownCounter for queue depth",
+      "description": "Uses an UpDownCounter (not Gauge or Counter) for tracking queue depth or any quantity that can both increase and decrease",
+      "max_score": 10
+    },
+    {
+      "name": "UCUM units specified",
+      "description": "Every metric creation call includes a unit using UCUM notation: 's' for seconds, '1' for dimensionless counts, 'By' for bytes",
+      "max_score": 8
+    },
+    {
+      "name": "No unit in metric name",
+      "description": "Metric names do NOT include the unit as a suffix (e.g., avoids names like '.seconds', '.milliseconds', '.bytes', '.ms')",
+      "max_score": 10
+    },
+    {
+      "name": "No semconv namespace clash",
+      "description": "Custom metric names do NOT start with reserved semconv namespace prefixes such as 'http.', 'db.', 'rpc.', 'messaging.', 'system.', 'process.' unless explicitly using the matching semconv metric",
+      "max_score": 8
+    },
+    {
+      "name": "No high-cardinality metric attributes",
+      "description": "Does NOT use unbounded identifiers (user.id, order.id, request.id, account.id, url.full, or ip.address) as metric attributes",
+      "max_score": 10
+    },
+    {
+      "name": "Bounded attribute values only",
+      "description": "Metric attributes use bounded-cardinality values: e.g., status bucketed by class ('success'/'error', or '2xx'/'4xx'/'5xx'), not exact codes or IDs",
+      "max_score": 8
+    },
+    {
+      "name": "No duplicate auto-instrumented metric",
+      "description": "Does NOT manually recreate a metric already emitted by auto-instrumentation (e.g., does not manually create 'http.server.request.duration' when @opentelemetry/instrumentation-http is already installed)",
+      "max_score": 10
+    },
+    {
+      "name": "Metric shape test",
+      "description": "Includes at least one integration test (or test stub) that asserts the expected shape of a custom metric: name, instrument type, unit, and attribute keys",
+      "max_score": 8
+    },
+    {
+      "name": "Consistent units across instances",
+      "description": "All metric creation calls for the same metric name use the same unit string (no mixing 's' and 'ms' for the same metric)",
+      "max_score": 5
+    },
+    {
+      "name": "Metric name not an attribute key",
+      "description": "No metric name is identical to a semantic convention attribute key (e.g., avoids naming a metric 'http.response.status_code')",
+      "max_score": 5
+    }
+  ]
+}

--- a/evals/otel-instrumentation-scenario-2/task.md
+++ b/evals/otel-instrumentation-scenario-2/task.md
@@ -1,0 +1,28 @@
+# Order Fulfillment Service Metrics
+
+## Problem Description
+
+ShopStream is a mid-size e-commerce platform whose order fulfillment service processes thousands of orders per day. The service is a Node.js application that already has `@opentelemetry/auto-instrumentations-node` installed and running (which handles HTTP server and HTTP client spans and metrics automatically).
+
+The engineering team has noticed that their observability dashboards show generic infrastructure metrics but nothing about the business operations that actually matter for SLA compliance. They want to add three custom metrics to the fulfillment service:
+
+1. **Order processing duration** — how long (in wall-clock time) it takes to fully process an order from receipt to completion. This needs percentile analysis (p50, p95, p99) to catch long-tail slowness.
+
+2. **Orders processed** — a running count of orders that have completed processing, broken down by outcome (fulfilled, cancelled, failed). This will be used for throughput rate calculation on dashboards.
+
+3. **Fulfillment queue depth** — the current number of orders waiting in the queue at any point in time. This can go up (when orders arrive) and down (when orders are processed or cancelled). Used for autoscaling decisions.
+
+The team's previous attempt added a metric called `http.server.orders.processed` that appeared to duplicate data the existing instrumentation already captured, and the unit was expressed as `orders.count.total` in the name itself. These problems caused backend cost issues and confusing dashboards.
+
+## Output Specification
+
+Produce the following files:
+
+1. **`metrics.js`** — A Node.js module that creates and exports the three metrics described above. Include the meter initialization and metric creation with all necessary configuration.
+
+2. **`fulfillment-service.js`** — A short example showing how the metrics are recorded in a realistic order processing workflow. Demonstrate incrementing/decrementing, recording durations, and what attributes are attached to each metric.
+
+3. **`metrics.test.js`** — Integration tests (using any test framework or plain Node.js assertions) that verify the shape of each custom metric: name, instrument type, unit, and attribute keys.
+
+The files should work with standard OpenTelemetry Node.js packages available on npm. Use placeholder values for any endpoint configuration.
+

--- a/evals/otel-instrumentation-scenario-3/criteria.json
+++ b/evals/otel-instrumentation-scenario-3/criteria.json
@@ -1,0 +1,61 @@
+{
+  "context": "Tests whether an agent correctly instruments a headless background worker, including creating a manual SERVER root span for a cron job, using correct span kinds for outbound calls, handling retry logic without incorrect ERROR status, recording exceptions as structured logs (not span events), and controlling span hygiene.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Manual SERVER root span",
+      "description": "Creates a manual span with kind SERVER (or INTERNAL) wrapping the entire headless job operation — not leaving the first DB/HTTP call as a CLIENT root span",
+      "max_score": 12
+    },
+    {
+      "name": "CLIENT kind for outbound calls",
+      "description": "Spans for database queries and external HTTP calls use SpanKind.CLIENT (not SpanKind.INTERNAL)",
+      "max_score": 10
+    },
+    {
+      "name": "AlwaysOn sampler preserved",
+      "description": "Does NOT set OTEL_TRACES_SAMPLER to 'traceidratio', 'parentbased_traceidratio', or any other sampler that drops spans — relies on default AlwaysOn",
+      "max_score": 10
+    },
+    {
+      "name": "ERROR only after retries exhausted",
+      "description": "Does NOT set span status to ERROR on a retry attempt that is later retried — sets ERROR only after the final retry fails",
+      "max_score": 10
+    },
+    {
+      "name": "Retry attempts as span events",
+      "description": "Records each failed retry attempt as a span event (e.g. span.addEvent) with attempt number or error details — before the final ERROR status is set",
+      "max_score": 8
+    },
+    {
+      "name": "ERROR status message",
+      "description": "When span status is set to ERROR, includes a non-empty status message containing the error class and a short description (not 'something went wrong' or empty)",
+      "max_score": 8
+    },
+    {
+      "name": "No span.recordException",
+      "description": "Does NOT use span.recordException(error) for exception recording — uses a structured log record with exception.type, exception.message, exception.stacktrace attributes instead",
+      "max_score": 10
+    },
+    {
+      "name": "Batch span instead of per-item spans",
+      "description": "Uses a single span with a batch.size attribute (or similar) for looping over a collection — does NOT create a new span for every item in a loop",
+      "max_score": 10
+    },
+    {
+      "name": "Exception log trace context",
+      "description": "Structured exception log records include trace_id and span_id extracted from the active span context",
+      "max_score": 8
+    },
+    {
+      "name": "forceFlush on shutdown",
+      "description": "Includes a graceful shutdown or crash handler that flushes the tracer provider before process exit (handles uncaughtException or SIGTERM)",
+      "max_score": 7
+    },
+    {
+      "name": "No more than 10 INTERNAL spans",
+      "description": "Code structure does not create more than 10 INTERNAL spans per job execution — avoids wrapping individual small helper calls in INTERNAL spans",
+      "max_score": 7
+    }
+  ]
+}

--- a/evals/otel-instrumentation-scenario-3/task.md
+++ b/evals/otel-instrumentation-scenario-3/task.md
@@ -1,0 +1,30 @@
+# Inventory Sync Worker Instrumentation
+
+## Problem Description
+
+DataBridge Inc. runs a nightly inventory synchronization worker that pulls updated stock levels from a third-party supplier API, reconciles them against an internal database, and flags discrepancies for review. The worker runs as a cron job (no inbound HTTP requests) on a schedule and is implemented in Node.js.
+
+The team recently added basic OpenTelemetry tracing to the worker but noticed that all their traces appear as disconnected CLIENT spans in the backend — making it impossible to see the full picture of what the worker is doing per run. They also have a retry mechanism for transient supplier API failures, but the traces show errors even for runs that ultimately succeed after a retry.
+
+The worker processes a batch of product SKUs per run (typically 200–500 items). A previous developer wrapped each individual SKU reconciliation in its own span, which generated thousands of tiny spans per run and caused the observability backend to reject the data as too high-cardinality.
+
+The worker structure is as follows:
+1. Fetch a batch of SKU updates from the supplier REST API (with up to 3 retries on 5xx or network errors)
+2. For each SKU in the batch, compare against the database record
+3. Write a summary of discrepancies to the database
+4. Log a completion event
+
+Occasionally the supplier API returns a 500 error or times out. When all retries are exhausted, the run should be marked as failed. If a retry succeeds, the run continues normally and should not be marked as failed.
+
+## Output Specification
+
+Produce the following files:
+
+1. **`worker.js`** — The main inventory sync worker implementation with full OpenTelemetry instrumentation. Include all tracing logic: root span setup, outbound call spans, retry handling, exception recording, and graceful shutdown.
+
+2. **`otel-setup.js`** — SDK initialization code that sets up the tracer provider and exporter. Include resource attributes and any crash handler registration.
+
+3. **`README.md`** — A short explanation (3–10 bullet points) of the key tracing decisions made in the implementation: why certain span kinds were chosen, how sampling is configured, and how the batch processing is instrumented.
+
+The files should be self-consistent. Use placeholder values for endpoint URLs and auth tokens. No real external services need to be called.
+

--- a/evals/otel-ottl-scenario-1/criteria.json
+++ b/evals/otel-ottl-scenario-1/criteria.json
@@ -1,0 +1,61 @@
+{
+  "context": "Tests whether the agent correctly configures a PII redaction pipeline: guards with nil checks, applies appropriate redaction strategies per data type, uses the filter processor for dropping entire records, sets error_mode in production, and orders processors correctly relative to enrichment.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "nil guard on redacted attrs",
+      "description": "Each redaction statement (set, replace_pattern, SHA256, delete_key on sensitive attributes) includes a `where <attribute> != nil` guard — NOT `where <attribute> != null`",
+      "max_score": 12
+    },
+    {
+      "name": "nil keyword not null",
+      "description": "Absence checks use `nil` (not `null`) throughout all OTTL statements",
+      "max_score": 8
+    },
+    {
+      "name": "error_mode set explicitly",
+      "description": "Every transform and filter processor block has an explicit `error_mode:` key set",
+      "max_score": 8
+    },
+    {
+      "name": "error_mode ignore in production",
+      "description": "All production processor configs use `error_mode: ignore` (not `propagate` or `silent`)",
+      "max_score": 8
+    },
+    {
+      "name": "SHA256 hash for emails/IDs",
+      "description": "Uses SHA256() to hash PII that should remain correlatable (e.g., user email or user ID), rather than replacing with a static placeholder",
+      "max_score": 10
+    },
+    {
+      "name": "replace_pattern for partial masking",
+      "description": "Uses replace_pattern() with a regex to partially mask structured values (e.g., credit card numbers) rather than replacing the entire value",
+      "max_score": 10
+    },
+    {
+      "name": "filter processor for full drops",
+      "description": "Uses the filter processor (not the transform processor) to drop entire log or span records that are entirely sensitive",
+      "max_score": 10
+    },
+    {
+      "name": "redaction after enrichment",
+      "description": "In the service pipeline, redaction/filter processors appear AFTER enrichment processors (e.g., resourcedetection, k8sattributes, resource) and BEFORE exporters",
+      "max_score": 10
+    },
+    {
+      "name": "delete_key for never-export attrs",
+      "description": "Uses delete_key() for attributes that must never be exported (not set to 'REDACTED' placeholder)",
+      "max_score": 10
+    },
+    {
+      "name": "set REDACTED for auth headers",
+      "description": "Uses set(<attr>, \"REDACTED\") for known sensitive headers (e.g., authorization, cookie) rather than hashing or masking",
+      "max_score": 8
+    },
+    {
+      "name": "debug exporter for validation",
+      "description": "Config includes or references a debug exporter (verbosity: detailed) as part of validation workflow, OR a comment explains the validation step",
+      "max_score": 6
+    }
+  ]
+}

--- a/evals/otel-ottl-scenario-1/task.md
+++ b/evals/otel-ottl-scenario-1/task.md
@@ -1,0 +1,18 @@
+# Securing Telemetry Before Export: PII Redaction Pipeline
+
+## Problem/Feature Description
+
+FinTech startup Meridian Payments runs an OpenTelemetry Collector that forwards traces and logs from their payment processing services to a third-party observability vendor. A recent security audit revealed that spans contain raw user email addresses in `user.email`, authorization headers in `http.request.header.authorization`, and session cookies in `http.request.header.cookie`. Some log records carry raw credit card numbers embedded in their body text. Occasionally, application misconfigurations cause RSA private keys to appear in log bodies.
+
+The engineering team wants to harden the pipeline before the next release. They want sensitive attributes scrubbed, partial values masked where possible, and records containing cryptographic key material dropped entirely before telemetry leaves the Collector. The pipeline already includes enrichment processors that add Kubernetes and environment metadata upstream; any redaction must happen after these enrichment stages so that the enriched attributes are available but no sensitive data reaches the exporter.
+
+## Output Specification
+
+Produce a complete OpenTelemetry Collector configuration file named `collector-config.yaml`. The config must define:
+
+- All necessary processors to redact, mask, hash, and drop the sensitive data described above
+- A service section that wires a `traces` pipeline and a `logs` pipeline, both starting from an `otlp` receiver, passing through any enrichment and redaction processors, and exiting through a `debug` exporter (use `verbosity: detailed`)
+- A brief `redaction-notes.md` file explaining which strategy was applied to each type of sensitive data and why
+
+The pipelines must be realistic enough that a reviewer can confirm correct processor ordering, correct redaction strategy per field type, and correct error handling configuration.
+

--- a/evals/otel-ottl-scenario-2/criteria.json
+++ b/evals/otel-ottl-scenario-2/criteria.json
@@ -1,0 +1,61 @@
+{
+  "context": "Tests whether the agent normalizes high-cardinality URL path attributes using replace_pattern with UUID and numeric ID patterns, applies attribute count and length limits, uses the resource processor for static attributes, uses transform to copy resource attributes to span level, and adds nil guards on all where clauses.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "UUID pattern normalization",
+      "description": "Uses replace_pattern() with a UUID regex (matching 8-4-4-4-12 hex groups) to replace UUID path segments in url.path and/or http.route with a fixed placeholder (e.g., `/{uuid}`)",
+      "max_score": 10
+    },
+    {
+      "name": "Numeric ID normalization",
+      "description": "Uses replace_pattern() with a numeric regex (e.g., `/\\d+`) to replace numeric path segments in url.path and/or http.route with a fixed placeholder (e.g., `/{id}`)",
+      "max_score": 10
+    },
+    {
+      "name": "nil guard on url.path",
+      "description": "All replace_pattern statements on url.path include a `where span.attributes[\"url.path\"] != nil` guard",
+      "max_score": 8
+    },
+    {
+      "name": "nil guard on http.route",
+      "description": "All replace_pattern statements on http.route include a `where span.attributes[\"http.route\"] != nil` guard",
+      "max_score": 8
+    },
+    {
+      "name": "limit() for attribute count",
+      "description": "Uses limit() to cap the number of attributes on spans (and/or logs) to prevent attribute-count cardinality explosion",
+      "max_score": 10
+    },
+    {
+      "name": "truncate_all() for value length",
+      "description": "Uses truncate_all() to cap the length of string attribute values on spans (and/or logs)",
+      "max_score": 10
+    },
+    {
+      "name": "resource processor for static attrs",
+      "description": "Uses the `resource` processor (not `transform`) to add static resource-level attributes such as environment name or cluster name",
+      "max_score": 12
+    },
+    {
+      "name": "transform to copy resource to span",
+      "description": "Uses the `transform` processor with set() to copy a resource attribute down to the span or log level (not the resource processor for this operation)",
+      "max_score": 10
+    },
+    {
+      "name": "error_mode set explicitly",
+      "description": "Every transform processor block includes an explicit `error_mode:` key",
+      "max_score": 8
+    },
+    {
+      "name": "error_mode ignore production",
+      "description": "All processor configs use `error_mode: ignore`",
+      "max_score": 6
+    },
+    {
+      "name": "nil keyword not null",
+      "description": "All absence checks use `nil` (not `null`) in OTTL conditions",
+      "max_score": 8
+    }
+  ]
+}

--- a/evals/otel-ottl-scenario-2/task.md
+++ b/evals/otel-ottl-scenario-2/task.md
@@ -1,0 +1,22 @@
+# Taming Metric Explosion: Cardinality Reduction for a REST API Fleet
+
+## Problem/Feature Description
+
+Platform engineering team at ShopStream runs dozens of microservices behind a REST API gateway. Their observability costs have tripled over the past quarter because spans emitted by the services include raw customer order IDs, user UUIDs, and product SKU numbers directly in the `url.path` and `http.route` attributes — for example paths like `/orders/4b2e1a90-3c4d-4e5f-8a1b-2c3d4e5f6a7b/items/12345`. Each unique path segment creates a distinct time series, overwhelming their backend's capacity.
+
+A secondary problem: some services emit spans with hundreds of attributes and string values that can be several kilobytes each, ballooning per-span storage. The team also wants to ensure that every span carries a `deployment.environment.name` attribute at the span level (not just at the resource level) so their dashboards can filter by environment without resource-level joins.
+
+The team needs a Collector configuration that normalizes paths, caps attribute counts, truncates long values, correctly adds static environment metadata, and propagates that metadata to individual spans.
+
+## Output Specification
+
+Produce a complete OpenTelemetry Collector configuration file named `collector-config.yaml` that covers:
+
+- Processor(s) for normalizing path attributes on spans
+- Processor(s) for limiting attribute count and truncating long attribute values
+- Processor(s) for setting static environment and cluster metadata
+- Processor(s) for propagating environment metadata from resource to span level
+- A `service` section wiring a `traces` pipeline from an `otlp` receiver through the processors to a `debug` exporter
+
+Also produce a `design-notes.md` file that briefly explains the processor choices made for each requirement (which processor type was used and why).
+

--- a/evals/otel-ottl-scenario-3/criteria.json
+++ b/evals/otel-ottl-scenario-3/criteria.json
@@ -1,0 +1,61 @@
+{
+  "context": "Tests whether the agent uses OTTL to filter stale telemetry with time comparisons using UnixNano(Now()), backfills missing log timestamps using the correct two-step pattern, uses int64 enum constants for span status/kind comparisons, uses IsMatch() with regex for pattern-based dropping, and uses nil as the absence keyword throughout.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "UnixNano(Now()) for stale drop",
+      "description": "Uses `time_unix_nano < UnixNano(Now()) - <offset>` (or equivalent) to drop data older than a defined threshold, using the UnixNano() and Now() functions",
+      "max_score": 12
+    },
+    {
+      "name": "Stale drop uses filter processor",
+      "description": "Stale data is dropped using the filter processor (not the transform processor)",
+      "max_score": 8
+    },
+    {
+      "name": "Timestamp backfill observed_time",
+      "description": "Uses `set(log.observed_time, Now()) where log.observed_time_unix_nano == 0` (or functionally equivalent) to backfill missing observed time",
+      "max_score": 10
+    },
+    {
+      "name": "Timestamp backfill log.time",
+      "description": "Uses `set(log.time, log.observed_time) where log.time_unix_nano == 0` (or functionally equivalent) to backfill missing log time from observed time",
+      "max_score": 10
+    },
+    {
+      "name": "Enum constant STATUS_CODE_ERROR",
+      "description": "Uses the int64 constant `STATUS_CODE_ERROR` (not an integer literal like `2` or a string) when comparing or setting span status code",
+      "max_score": 12
+    },
+    {
+      "name": "IsMatch() for pattern filtering",
+      "description": "Uses IsMatch() with a regex pattern to filter out (drop or flag) metrics or spans matching a name pattern",
+      "max_score": 10
+    },
+    {
+      "name": "filter processor for metric drops",
+      "description": "Metrics dropped by pattern use the filter processor (not transform with a delete operation)",
+      "max_score": 8
+    },
+    {
+      "name": "nil for absence checks",
+      "description": "All where-clause absence checks use `!= nil` (not `!= null`)",
+      "max_score": 8
+    },
+    {
+      "name": "error_mode set explicitly",
+      "description": "Every processor that uses OTTL includes an explicit `error_mode:` key",
+      "max_score": 8
+    },
+    {
+      "name": "error_mode ignore in production",
+      "description": "All OTTL processors use `error_mode: ignore`",
+      "max_score": 8
+    },
+    {
+      "name": "where clause nil guards on attrs",
+      "description": "Statements that operate on span or log attributes include `where <attr> != nil` guards before acting on those attributes",
+      "max_score": 6
+    }
+  ]
+}

--- a/evals/otel-ottl-scenario-3/task.md
+++ b/evals/otel-ottl-scenario-3/task.md
@@ -1,0 +1,24 @@
+# Cleaning Up a Noisy Observability Pipeline: Stale Data, Missing Timestamps, and Error Tracing
+
+## Problem/Feature Description
+
+DataVault, a cloud storage provider, runs an OpenTelemetry Collector aggregating metrics, traces, and logs from their Kubernetes infrastructure and application services. Three problems have built up that are increasing their observability costs and reducing signal quality:
+
+1. **Stale buffered data**: During incidents, some services queue up telemetry and replay it hours later. The backend rejects anything older than six hours but still bills for ingestion. The team wants the Collector to drop any data with a timestamp older than six hours before it reaches the exporter.
+
+2. **Missing log timestamps**: A legacy logging library emits log records with no timestamps set. Downstream tooling fails to sort these logs correctly. The team wants the Collector to backfill both the observed time and the record time on any log that has neither.
+
+3. **Noise reduction in metrics**: The Kubernetes control plane emits hundreds of `k8s.replicaset.*` metrics that DataVault's dashboards never use. The team wants these dropped at the Collector to reduce ingestion volume. Additionally, the team wants to mark any HTTP server span that completed with a 5xx status as an error span so that error-rate dashboards work correctly.
+
+## Output Specification
+
+Produce a complete OpenTelemetry Collector configuration file named `collector-config.yaml` with:
+
+- Processor(s) that drop telemetry older than six hours
+- Processor(s) that backfill timestamps on log records missing them  
+- Processor(s) that drop the unwanted Kubernetes replicaset metrics
+- Processor(s) that mark 5xx HTTP spans as error spans using the correct span status field
+- A `service` section wiring separate `traces`, `metrics`, and `logs` pipelines from an `otlp` receiver through the processors to a `debug` exporter
+
+Also produce a `pipeline-notes.md` explaining the approach taken for each of the four requirements, including which OTTL constructs were chosen and why.
+

--- a/evals/otel-semantic-conventions-scenario-1/criteria.json
+++ b/evals/otel-semantic-conventions-scenario-1/criteria.json
@@ -1,0 +1,61 @@
+{
+  "context": "Tests whether the agent correctly updates deprecated OpenTelemetry HTTP attribute names to their current equivalents, applies the correct URL attributes for client vs server spans, renames HTTP duration metrics and their units, and handles non-standard HTTP method values using the _OTHER pattern.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "http.request.method used",
+      "description": "Uses `http.request.method` instead of the deprecated `http.method` for HTTP method attribute",
+      "max_score": 10
+    },
+    {
+      "name": "http.response.status_code used",
+      "description": "Uses `http.response.status_code` instead of the deprecated `http.status_code`",
+      "max_score": 10
+    },
+    {
+      "name": "url.full on client spans",
+      "description": "Uses `url.full` on CLIENT (outbound) HTTP spans instead of deprecated `http.url`",
+      "max_score": 10
+    },
+    {
+      "name": "url.path on server spans",
+      "description": "Uses `url.path` (and `url.query` where applicable) on SERVER (inbound) spans instead of `http.target`",
+      "max_score": 8
+    },
+    {
+      "name": "url.full NOT on server spans",
+      "description": "Does NOT use `url.full` on SERVER spans — only `url.path`, `url.query`, `url.scheme`",
+      "max_score": 8
+    },
+    {
+      "name": "server.address used",
+      "description": "Uses `server.address` instead of deprecated `net.peer.name` or `net.host.name`",
+      "max_score": 8
+    },
+    {
+      "name": "url.scheme used",
+      "description": "Uses `url.scheme` instead of deprecated `http.scheme`",
+      "max_score": 6
+    },
+    {
+      "name": "user_agent.original used",
+      "description": "Uses `user_agent.original` instead of deprecated `http.user_agent`",
+      "max_score": 6
+    },
+    {
+      "name": "Metric name updated",
+      "description": "Uses `http.server.request.duration` (and/or `http.client.request.duration`) instead of deprecated `http.server.duration` / `http.client.duration`",
+      "max_score": 10
+    },
+    {
+      "name": "Duration unit seconds",
+      "description": "HTTP duration metric is recorded in seconds (e.g., `0.245`), NOT milliseconds (e.g., `245`)",
+      "max_score": 10
+    },
+    {
+      "name": "_OTHER normalization",
+      "description": "Non-standard HTTP method values are set to `_OTHER` in `http.request.method`, with the original value stored in `http.request.method_original`",
+      "max_score": 14
+    }
+  ]
+}

--- a/evals/otel-semantic-conventions-scenario-1/task.md
+++ b/evals/otel-semantic-conventions-scenario-1/task.md
@@ -1,0 +1,83 @@
+# Modernize Payment Gateway Telemetry
+
+## Problem/Feature Description
+
+Finpay is a B2B payments platform that processes transactions on behalf of thousands of merchants. Their Python service was instrumented with OpenTelemetry approximately two years ago, and it has been running fine since then — but their observability tooling has recently started flagging schema inconsistencies in dashboards and queries. A platform engineer has traced the root cause to the telemetry instrumentation: the attribute names and metric names in use are now outdated and no longer match what their observability backend expects.
+
+The team needs the instrumentation updated to use current OpenTelemetry semantic convention attribute names, correct metric names, and proper metric units. The service handles both inbound payment requests (acting as an HTTP server) and outbound calls to card network APIs (acting as an HTTP client), so both directions of HTTP span instrumentation must be addressed. Some edge-case payment methods (like "SEPA_DEBIT" or "WIRE_TRANSFER") are not standard HTTP verbs, and the service needs to handle these gracefully when they appear in HTTP method-like classification attributes.
+
+## Output Specification
+
+Produce an updated version of the instrumentation module at `output/instrumentation.py`. The updated module should contain the same structure as the input file but with all attribute and metric names updated to their current equivalents.
+
+Also produce a short migration notes file at `output/migration_notes.md` listing what was changed and why (keep it brief — a bullet per change is enough).
+
+## Input Files
+
+The following files are provided as inputs. Extract them before beginning.
+
+=============== FILE: inputs/instrumentation.py ===============
+"""
+Finpay payment gateway telemetry instrumentation.
+Initialises OpenTelemetry tracing and metrics for the payment processing service.
+"""
+import time
+from opentelemetry import trace, metrics
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.metrics import MeterProvider
+
+tracer = trace.get_tracer(__name__)
+meter = metrics.get_meter(__name__)
+
+# Metric: track how long inbound payment requests take
+server_duration = meter.create_histogram(
+    name="http.server.duration",
+    description="Duration of inbound HTTP requests",
+    unit="ms",
+)
+
+# Metric: track how long outbound card-network calls take
+client_duration = meter.create_histogram(
+    name="http.client.duration",
+    description="Duration of outbound HTTP calls to card networks",
+    unit="ms",
+)
+
+
+def record_inbound_request(method, path, query, scheme, status_code, user_agent, duration_ms):
+    """Create a SERVER span for an inbound payment request."""
+    with tracer.start_as_current_span("payment.inbound") as span:
+        span.set_attribute("http.method", method)
+        span.set_attribute("http.target", f"{path}?{query}" if query else path)
+        span.set_attribute("http.scheme", scheme)
+        span.set_attribute("http.status_code", status_code)
+        span.set_attribute("http.user_agent", user_agent)
+
+        server_duration.record(
+            duration_ms,
+            {
+                "http.method": method,
+                "http.status_code": status_code,
+                "http.route": "/v1/payments/{payment_id}",
+            }
+        )
+
+
+def record_outbound_call(method, full_url, peer_host, peer_port, status_code, http_version, duration_ms):
+    """Create a CLIENT span for an outbound call to a card network API."""
+    with tracer.start_as_current_span("cardnetwork.call") as span:
+        span.set_attribute("http.method", method)
+        span.set_attribute("http.url", full_url)
+        span.set_attribute("net.peer.name", peer_host)
+        span.set_attribute("net.peer.port", peer_port)
+        span.set_attribute("http.status_code", status_code)
+        span.set_attribute("http.flavor", http_version)
+
+        client_duration.record(
+            duration_ms,
+            {
+                "http.method": method,
+                "http.status_code": status_code,
+            }
+        )
+

--- a/evals/otel-semantic-conventions-scenario-2/criteria.json
+++ b/evals/otel-semantic-conventions-scenario-2/criteria.json
@@ -1,0 +1,56 @@
+{
+  "context": "Tests whether the agent correctly names custom (domain-specific) attributes using a reverse-DNS namespace prefix, avoids bare attribute names, chooses low-cardinality dimensions for metric instruments, avoids placing user or request identity on metric data points, and correctly places user identity attributes at span/log level rather than as resource attributes.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Reverse-DNS namespace prefix",
+      "description": "All custom (domain-specific) attributes use a reverse-DNS-style prefix (e.g., `com.company.`, `io.company.`) rather than bare names",
+      "max_score": 15
+    },
+    {
+      "name": "No bare custom attribute names",
+      "description": "Does NOT use bare unnamespaced custom attribute names such as `order_priority`, `merchant_tier`, or `payment_method` — every custom attribute has a dotted namespace prefix",
+      "max_score": 10
+    },
+    {
+      "name": "http.route in metric dimensions",
+      "description": "Uses `http.route` (e.g., `/v1/orders/{order_id}`) as a metric dimension for HTTP request metrics, NOT `url.path`",
+      "max_score": 10
+    },
+    {
+      "name": "No url.path in metrics",
+      "description": "Does NOT use `url.path` as an attribute on any metric instrument (histogram, counter, gauge)",
+      "max_score": 10
+    },
+    {
+      "name": "No user/order IDs in metric dimensions",
+      "description": "Does NOT use user IDs, order IDs, merchant IDs, or other high-cardinality identifiers as dimensions/labels on any metric instrument",
+      "max_score": 10
+    },
+    {
+      "name": "User identity on spans not resource",
+      "description": "User identity attributes (e.g., `user.id`, `enduser.id`) are set on spans or log records, NOT on the resource",
+      "max_score": 12
+    },
+    {
+      "name": "service.name on resource",
+      "description": "Sets `service.name` on the Resource object, NOT as a span attribute",
+      "max_score": 8
+    },
+    {
+      "name": "deployment.environment.name used",
+      "description": "Uses `deployment.environment.name` (not deprecated `deployment.environment`) when setting the deployment environment",
+      "max_score": 8
+    },
+    {
+      "name": "Registry attributes not reinvented",
+      "description": "Uses standard registry attributes (e.g., `http.request.method`, `http.response.status_code`) where applicable, rather than inventing custom equivalents",
+      "max_score": 10
+    },
+    {
+      "name": "High-cardinality values on spans",
+      "description": "High-cardinality values (order IDs, merchant IDs, user IDs) are placed as span attributes, not as metric data point labels",
+      "max_score": 7
+    }
+  ]
+}

--- a/evals/otel-semantic-conventions-scenario-2/task.md
+++ b/evals/otel-semantic-conventions-scenario-2/task.md
@@ -1,0 +1,20 @@
+# Add Observability to the Order Management Service
+
+## Problem/Feature Description
+
+Threadline is a B2B e-commerce platform that connects clothing manufacturers with wholesale buyers. Their Python order management service handles order creation, status updates, and fulfillment routing. The service is multi-tenant — each request belongs to a specific merchant account, and orders have varying priority levels (standard, express, white-glove) that influence routing.
+
+The platform team wants to add OpenTelemetry instrumentation to this service so they can trace individual order operations and measure aggregate throughput and latency. As they grow, they expect tens of millions of orders per month across thousands of merchant accounts. The observability platform they use requires well-structured telemetry to keep storage costs under control — they have already had one incident where unbounded label cardinality caused a metrics backend to fall over, and they are keen to avoid a repeat.
+
+The service exposes a REST API over HTTP. Each API call is associated with an authenticated merchant (by merchant ID) and, after the order is created, with a specific order ID. Orders have a business-specific priority level that the operations team wants to see in telemetry for routing analysis.
+
+## Output Specification
+
+Produce a Python module at `output/instrumentation.py` that demonstrates the telemetry setup for this service. It should include:
+- Resource configuration (setting service identity and environment)
+- A server span for a typical order creation request, including the merchant ID, order ID, and order priority as attributes
+- A histogram metric for tracking order creation latency, with appropriate dimensions
+- Wherever you create a custom attribute name for a Threadline-specific concept, use the company domain `threadline.io`
+
+Also produce a brief `output/attribute_decisions.md` explaining the key attribute placement decisions you made — one or two sentences per decision is enough.
+

--- a/evals/otel-semantic-conventions-scenario-3/criteria.json
+++ b/evals/otel-semantic-conventions-scenario-3/criteria.json
@@ -1,0 +1,56 @@
+{
+  "context": "Tests whether the agent correctly configures resource attributes for a Kubernetes-hosted microservice, uses k8s.pod.uid instead of k8s.pod.ip, sets peer.service or server.address on client spans to enable service topology, avoids placing Kubernetes/service identity attributes on individual spans, and does not manually set Dash0-derived or otel.* attributes.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "service.name as resource attr",
+      "description": "Sets `service.name` on the Resource object, NOT on individual spans",
+      "max_score": 10
+    },
+    {
+      "name": "service.version as resource attr",
+      "description": "Sets `service.version` on the Resource object",
+      "max_score": 8
+    },
+    {
+      "name": "deployment.environment.name",
+      "description": "Sets `deployment.environment.name` (not deprecated `deployment.environment`) as a resource attribute",
+      "max_score": 8
+    },
+    {
+      "name": "k8s.pod.uid not k8s.pod.ip",
+      "description": "Uses `k8s.pod.uid` as the Kubernetes pod identifier resource attribute, NOT `k8s.pod.ip`",
+      "max_score": 12
+    },
+    {
+      "name": "service.name NOT on spans",
+      "description": "Does NOT set `service.name` as a span attribute on any span",
+      "max_score": 10
+    },
+    {
+      "name": "k8s metadata NOT on spans",
+      "description": "Does NOT set `k8s.pod.name`, `k8s.pod.uid`, or other Kubernetes metadata as span attributes",
+      "max_score": 8
+    },
+    {
+      "name": "peer.service or server.address on client spans",
+      "description": "Sets `peer.service` or `server.address` on CLIENT spans representing calls to downstream services",
+      "max_score": 12
+    },
+    {
+      "name": "Correct span kinds",
+      "description": "Uses appropriate span kinds: SERVER for inbound requests, CLIENT for outbound service calls — does NOT use INTERNAL for spans that cross service boundaries",
+      "max_score": 10
+    },
+    {
+      "name": "No manual dash0.* attributes",
+      "description": "Does NOT manually set any `dash0.*` attributes (e.g., `dash0.operation.name`, `dash0.span.type`) — these are derived automatically",
+      "max_score": 12
+    },
+    {
+      "name": "service.instance.id set",
+      "description": "Sets `service.instance.id` on the Resource object to uniquely identify this pod/instance",
+      "max_score": 10
+    }
+  ]
+}

--- a/evals/otel-semantic-conventions-scenario-3/task.md
+++ b/evals/otel-semantic-conventions-scenario-3/task.md
@@ -1,0 +1,22 @@
+# Bootstrap Observability for Inventory Microservice
+
+## Problem/Feature Description
+
+Stackmart is a retail technology company running a microservices platform on Kubernetes. Their inventory service is a new Python service that is about to go into production. It exposes a REST API consumed by two other internal services: the order service and the warehouse management service. It also makes outbound calls to a third-party supplier catalog API to fetch product availability data.
+
+The infrastructure team is standardising how all new services are instrumented before they ship to production. They use Dash0 as their observability backend and have noticed that a previous service set up its telemetry incorrectly — the service dependency topology graph was broken because client spans lacked the attributes needed to draw edges to downstream services, and some Kubernetes-specific metadata that ended up on every span caused unexpectedly high data volumes and broke cross-service correlation.
+
+The team wants the new inventory service to be set up correctly from the start, with all the resource attributes Dash0 needs, proper span configuration for both incoming and outgoing calls, and nothing that would interfere with Dash0's own enrichment pipeline.
+
+The service runs in a Kubernetes pod. The pod UID is available at runtime via the Downward API (assume it is available as the environment variable `K8S_POD_UID`). The pod name is available as `K8S_POD_NAME`. The service version is `1.0.0` and the deployment environment is `production`.
+
+## Output Specification
+
+Produce a Python module at `output/otel_setup.py` that:
+- Initialises the OpenTelemetry SDK with a correctly configured Resource
+- Shows a representative SERVER span for an inbound inventory lookup request
+- Shows a representative CLIENT span for an outbound call to the supplier catalog API at `catalog.supplier.example.com`
+- Includes inline comments where a choice or placement decision needs explanation for a future reader
+
+Also produce `output/setup_notes.md` with a brief explanation of any non-obvious decisions made in the setup.
+


### PR DESCRIPTION
## Summary

Adds a top-level `evals/` folder containing 12 eval scenarios — 3 per skill — for the four skills in this tile:

- `otel-collector`
- `otel-instrumentation`
- `otel-ottl`
- `otel-semantic-conventions`

Each `evals/<skill>-scenario-<N>/` folder has:
- `task.md` — the scenario task prompt
- `criteria.json` — a weighted-checklist rubric (context + scoring items)

Scenarios were generated by the Tessl eval pipeline and represent the same content surfaced in the Tessl registry at `tessl.io/registry/dash0/agent-skills`. Sharing them in-repo so they can be reviewed, edited, and re-used directly alongside the skills.

## Test plan

- [ ] Skim a couple of `task.md` / `criteria.json` pairs to confirm they match expected scenario content for the relevant skill
- [ ] Confirm folder naming convention (`<skill>-scenario-<N>/`) is acceptable