### PR TITLE
feat(otel-collector): add serverless / sidecar-less deployment rule

### DIFF
--- a/skills/otel-collector/README.md
+++ b/skills/otel-collector/README.md
@@ -15,6 +15,7 @@ otel-collector/
     ├── pipelines.md      # Service section, per-signal config, connectors
     ├── deployment.md     # Agent vs gateway patterns, deployment method selection
     ├── deployment/
+    │   ├── serverless.md             # Direct SDK export (App Runner, Cloud Run, Lambda)
     │   ├── collector-helm-chart.md    # Collector Helm chart
     │   ├── opentelemetry-operator.md  # OTel Operator and auto-instrumentation
     │   ├── dash0-operator.md         # Dash0 Kubernetes Operator
@@ -44,6 +45,7 @@ The skill activates automatically when working on Collector configuration tasks.
 | [deployment](./rules/deployment.md) | HIGH | Agent vs gateway patterns, deployment method selection |
 | [raw-manifests](./rules/deployment/raw-manifests.md) | HIGH | Raw Kubernetes manifests — DaemonSet, Deployment, RBAC, Docker Compose |
 | [dash0-operator](./rules/deployment/dash0-operator.md) | HIGH | Dash0 Kubernetes Operator — automated instrumentation and Collector management |
+| [serverless](./rules/deployment/serverless.md) | HIGH | Serverless and sidecar-less platforms: direct SDK-to-backend export, no Collector |
 | [sampling](./rules/sampling.md) | HIGH | Head sampling, tail sampling, load balancing |
 | [red-metrics](./rules/red-metrics.md) | HIGH | Semconv-aligned RED metrics from traces |
 

--- a/skills/otel-collector/SKILL.md
+++ b/skills/otel-collector/SKILL.md
@@ -24,6 +24,7 @@ Expert guidance for configuring and deploying the OpenTelemetry Collector to rec
 | [processors](./rules/processors.md) | Processors — memory limiter, resource detection, ordering, sending queue |
 | [pipelines](./rules/pipelines.md) | Pipelines — service section, per-signal configuration, connectors |
 | [deployment](./rules/deployment.md) | Deployment — agent vs gateway patterns, deployment method selection |
+| [serverless](./rules/deployment/serverless.md) | Serverless / sidecar-less containers (App Runner, Cloud Run, Fly, Lambda) — direct SDK-to-backend export, no Collector |
 | [dash0-operator](./rules/deployment/dash0-operator.md) | Dash0 Kubernetes Operator — automated instrumentation, Collector management, Dash0 export |
 | [collector-helm-chart](./rules/deployment/collector-helm-chart.md) | Collector Helm chart — presets, modes, image selection |
 | [opentelemetry-operator](./rules/deployment/opentelemetry-operator.md) | OpenTelemetry Operator — Collector CRD, auto-instrumentation, sidecar |
@@ -100,7 +101,7 @@ See [exporters](./rules/exporters.md) for full authentication and queue configur
 
 1. **Write config** — define receivers, processors, and exporters; wire them in `service.pipelines`.
 2. **Validate locally** — run `otelcol validate --config=config.yaml` to catch structural errors before deployment.
-3. **Deploy** — choose a deployment method from the [deployment](./rules/deployment.md) rule (Helm, Operator, raw manifests, or Docker Compose).
+3. **Deploy** — choose a deployment method from the [deployment](./rules/deployment.md) rule (Helm, Operator, raw manifests, Docker Compose, or — when you cannot run a Collector at all — [direct SDK export on serverless](./rules/deployment/serverless.md)).
 4. **Verify** — add the `debug` exporter to a pipeline temporarily and inspect stdout to confirm telemetry is flowing; then remove it before going to production.
 
 ## Quick reference

--- a/skills/otel-collector/rules/deployment.md
+++ b/skills/otel-collector/rules/deployment.md
@@ -19,27 +19,31 @@ Choose the pattern based on what telemetry you collect and how you process it.
 Follow these steps in order.
 Stop at the first match.
 
-### 1. Is the target environment Kubernetes?
+### 1. Can you run a Collector next to the app at all?
+
+On **serverless / sidecar-less container platforms** (AWS App Runner, Google Cloud Run, Fly.io, Azure Container Apps, container-image Lambda) you cannot deploy a co-located Collector. Use **[direct SDK-to-backend export](./deployment/serverless.md)** — the SDK ships OTLP straight to the backend, no Collector in the path. Stop here.
+
+### 2. Is the target environment Kubernetes?
 
 If **no** — use [Docker Compose or a binary](./deployment/raw-manifests.md#docker-compose-for-local-development) for local development, or a system service for bare-metal hosts.
 The remaining steps apply only to Kubernetes.
 
-### 2. Is Dash0 the observability backend?
+### 3. Is Dash0 the observability backend?
 
 If **yes** and you do not need custom Collector pipelines (custom processors, connectors, or non-standard receivers) — use the **[Dash0 Kubernetes Operator](./deployment/dash0-operator.md)**.
 It deploys and manages Collectors automatically, injects instrumentation without per-workload annotations, and synchronises dashboards and alert rules.
 
-If **yes** but you need full control over the Collector pipeline — continue to step 3.
+If **yes** but you need full control over the Collector pipeline — continue to step 4.
 Configure the Collector to export to Dash0 via OTLP (see [exporters](./exporters.md)).
 
-### 3. Do you need automatic SDK instrumentation injected into application pods?
+### 4. Do you need automatic SDK instrumentation injected into application pods?
 
 If **yes** — use the **[OpenTelemetry Operator](./deployment/opentelemetry-operator.md)**.
 It manages Collector instances via the `OpenTelemetryCollector` CRD and injects language-specific auto-instrumentation via the `Instrumentation` CRD.
 
-If **no** — continue to step 4.
+If **no** — continue to step 5.
 
-### 4. Is Helm available in the cluster?
+### 5. Is Helm available in the cluster?
 
 If **yes** — use the **[Collector Helm chart](./deployment/collector-helm-chart.md)**.
 Presets handle RBAC, volumes, and common receivers automatically.
@@ -50,6 +54,9 @@ If **no** — use **[raw Kubernetes manifests](./deployment/raw-manifests.md)**.
 ### Summary
 
 ```
+Can you run a Collector next to the app?
+├─ No (serverless: App Runner, Cloud Run, Fly, Lambda) → Direct SDK export (serverless.md)
+└─ Yes
 Is the target Kubernetes?
 ├─ No  → Docker Compose / binary
 └─ Yes
@@ -86,6 +93,7 @@ The [Dash0 Kubernetes Operator](./deployment/dash0-operator.md) manages this top
 
 ## References
 
+- [Serverless / sidecar-less (direct SDK export)](./deployment/serverless.md)
 - [Raw manifests](./deployment/raw-manifests.md)
 - [Collector Helm chart](./deployment/collector-helm-chart.md)
 - [OpenTelemetry Operator](./deployment/opentelemetry-operator.md)

--- a/skills/otel-collector/rules/deployment/serverless.md
+++ b/skills/otel-collector/rules/deployment/serverless.md
@@ -1,0 +1,147 @@
+---
+title: "Serverless / sidecar-less containers"
+impact: HIGH
+tags:
+  - deployment
+  - serverless
+  - app-runner
+  - cloud-run
+  - fly
+  - lambda
+  - direct-export
+---
+
+# Serverless and sidecar-less container platforms
+
+On managed container platforms you often **cannot run a Collector** next to
+your app: there is no pod to add a sidecar to, no host to run a DaemonSet on,
+and no way to co-locate a process. Examples: **AWS App Runner**, **Google
+Cloud Run**, **Fly.io Machines**, **Azure Container Apps**, and
+container-image **AWS Lambda**.
+
+The pattern here is the opposite of the Kubernetes patterns in
+[deployment](../deployment.md): instead of the SDK exporting to a nearby
+Collector, the **SDK exports OTLP directly to the backend's OTLP endpoint**.
+There is no Collector in the request path.
+
+## When to use this
+
+Use direct SDK-to-backend export when **all** of these hold:
+
+- You cannot deploy a Collector as a sidecar, DaemonSet, or co-process.
+- Your telemetry volume is per-instance and modest (one app, not an
+  aggregation point for many services).
+- You do not need Collector-side processing (tail sampling, cross-signal
+  enrichment, OTTL redaction) before egress.
+
+If you outgrow this (need sampling, redaction, or fan-in from many services),
+run a **gateway Collector** as a separate always-on service and point the
+serverless apps' `OTEL_EXPORTER_OTLP_ENDPOINT` at it. That is the one
+Collector topology that fits serverless: remote, not co-located.
+
+## Configuration (direct export)
+
+Drive everything through the SDK's environment variables — no Collector
+config file. See the language SDK rules under `otel-instrumentation` for the
+activation mechanism (e.g. Node.js uses a `NODE_OPTIONS` register hook).
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=https://<backend-otlp-endpoint>
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+# auth header per your backend, e.g. for Dash0:
+#   Authorization=Bearer <auth-token>,Dash0-Dataset=<dataset>
+OTEL_EXPORTER_OTLP_HEADERS=<backend auth headers>
+OTEL_TRACES_EXPORTER=otlp
+OTEL_METRICS_EXPORTER=otlp
+OTEL_LOGS_EXPORTER=otlp
+OTEL_SERVICE_NAME=<service>
+OTEL_RESOURCE_ATTRIBUTES=service.namespace=<ns>,deployment.environment=<env>
+```
+
+- **Protocol:** prefer `http/protobuf`. Serverless egress is HTTPS on 443;
+  many of these platforms do not give you an arbitrary-port gRPC path, and
+  OTLP-over-HTTP is universally reachable on 443. (Contrast with the
+  Collector-to-backend path in [exporters](../exporters.md), which uses gRPC.)
+- **Endpoint:** your backend's OTLP ingest endpoint (for Dash0, the org's
+  Settings then Endpoints page). It is usually **not** the same host as the
+  backend's query or REST API.
+
+## The two things that bite you on serverless
+
+### 1. Egress must actually reach the internet
+
+Direct export only works if the container can make outbound HTTPS to the
+backend's OTLP endpoint. On platforms with **VPC-only egress and no NAT/internet
+route**, the exporter silently fails (connection timeouts, no spans, no
+error surfaced to the user). This is the most common "I set everything and
+see nothing" cause.
+
+- **AWS App Runner** with `EgressType: VPC`: the VPC needs a **NAT gateway**
+  (or the ingress reached some other way). App Runner's default
+  (`EgressType: DEFAULT`, AWS-managed egress) already has internet access.
+- **Cloud Run / Container Apps:** default egress reaches the internet;
+  a VPC connector with "all traffic" routing plus no Cloud NAT does not.
+
+Verify egress before debugging the SDK: `curl -sS -o /dev/null -w '%{http_code}' https://<backend-otlp-endpoint>` from inside the container (or a same-network task) should not hang.
+
+### 2. Keep the ingest token out of your IaC
+
+Deliver `OTEL_EXPORTER_OTLP_HEADERS` (which embeds the auth token) from the
+platform's **secret store**, not as a plaintext environment variable in your
+template:
+
+- App Runner: `RuntimeEnvironmentSecrets` → a Secrets Manager secret holding
+  the full header string (for Dash0: `Authorization=Bearer <token>,Dash0-Dataset=<ds>`).
+- Cloud Run: `--set-secrets` from Secret Manager.
+- Fly: `fly secrets set`.
+
+Store the whole header string as one secret (env vars cannot be composed from
+parts at runtime), and mint it out of band so the token never lands in a
+committed file or a CloudFormation/Terraform parameter.
+
+## Flush on shutdown
+
+Serverless platforms send `SIGTERM` on every scale-in and rolling replace,
+which is far more frequent than a long-lived VM. Batched spans buffered at
+that moment are lost unless the SDK flushes on shutdown. Most language
+auto-instrumentation registers a `SIGTERM`/`SIGINT` flush hook automatically;
+confirm it for your SDK, and additionally flush on `uncaughtException` /
+unhandled rejection (see the language rule, e.g. `otel-instrumentation`'s
+Node.js graceful-shutdown section). Short-lived function runtimes
+(Lambda) should use the platform's OTel Lambda layer / `BatchSpanProcessor`
+with a forced flush before the handler returns.
+
+## Worked example: AWS App Runner (Node.js container, Dash0 as the backend)
+
+No Collector. The image adds `@opentelemetry/auto-instrumentations-node`; the
+App Runner service sets the register hook and the OTLP env vars; the ingest
+token is a Secrets Manager secret injected as `OTEL_EXPORTER_OTLP_HEADERS`;
+the service's VPC has a NAT gateway so OTLP reaches the ingress.
+
+```yaml
+# CloudFormation: AWS::AppRunner::Service > SourceConfiguration >
+# ImageRepository > ImageConfiguration
+RuntimeEnvironmentVariables:
+  - { Name: NODE_OPTIONS, Value: "--require @opentelemetry/auto-instrumentations-node/register" }
+  - { Name: OTEL_SERVICE_NAME, Value: my-service }
+  - { Name: OTEL_TRACES_EXPORTER, Value: otlp }
+  - { Name: OTEL_METRICS_EXPORTER, Value: otlp }
+  - { Name: OTEL_LOGS_EXPORTER, Value: otlp }
+  - { Name: OTEL_EXPORTER_OTLP_PROTOCOL, Value: http/protobuf }
+  - { Name: OTEL_EXPORTER_OTLP_ENDPOINT, Value: https://ingress.eu-west-1.aws.dash0.com }
+  - { Name: OTEL_RESOURCE_ATTRIBUTES, Value: "service.namespace=my-ns,deployment.environment=production" }
+RuntimeEnvironmentSecrets:
+  # secret value: Authorization=Bearer <token>,Dash0-Dataset=<dataset>
+  - { Name: OTEL_EXPORTER_OTLP_HEADERS, Value: <secret-arn> }
+```
+
+The result is identical to a Collector deployment from the backend's side — spans,
+metrics, and logs arrive over OTLP — but with zero Collector infrastructure
+to run or pay for.
+
+## References
+
+- [Deployment decision process](../deployment.md)
+- [Exporters (Collector-to-Dash0, gRPC)](../exporters.md)
+- Language SDK setup: the `otel-instrumentation` skill (per-language rules)
+- [OpenTelemetry Collector deployment patterns](https://opentelemetry.io/docs/collector/deployment/)

--- a/skills/otel-instrumentation/rules/sdks/nodejs.md
+++ b/skills/otel-instrumentation/rules/sdks/nodejs.md
@@ -224,6 +224,15 @@ See [resource attributes](../resources.md) for the full list of required and rec
 
 See [Kubernetes deployment](../platforms/k8s.md) for pod metadata injection, resource attributes, and Dash0 Kubernetes Operator guidance.
 
+## Serverless / sidecar-less deployment
+
+On AWS App Runner, Google Cloud Run, Fly.io, Azure Container Apps, or
+container-image Lambda you cannot run a Collector next to the app. Set the
+`OTEL_EXPORTER_OTLP_*` variables above to export **directly to the backend**
+and mind the two serverless pitfalls (internet egress must reach the ingress;
+keep the ingest token in the platform's secret store). See the
+`otel-collector` skill's [serverless deployment rule](../../../otel-collector/rules/deployment/serverless.md) for the full pattern and an App Runner worked example.
+
 ## Supported libraries
 
 The auto-instrumentation package automatically instruments:


### PR DESCRIPTION
## What this adds

The deployment decision tree dead-ended for platforms where you cannot run a co-located Collector: AWS App Runner, Google Cloud Run, Fly.io, Azure Container Apps, and container-image Lambda. This adds `rules/deployment/serverless.md` covering the direct SDK-to-Dash0 OTLP export pattern:

- http/protobuf on 443 (serverless egress rarely offers an arbitrary-port gRPC path)
- The ingest token delivered via the platform's secret store, never through IaC parameters
- The egress pitfall that bites everyone: VPC-only egress without a NAT fails silently (spans just never arrive)
- Shutdown flush on SIGTERM-heavy platforms
- A worked AWS App Runner CloudFormation example

Routes step 1 of the deployment decision process to the new rule, registers it in the SKILL.md rules table and README, and cross-links from the Node.js SDK rule.

## Why

Grounded in a real instrumentation of a production App Runner app: this pattern is how its telemetry ships to Dash0 today. The rule keeps to this repo's "this is good OTel" scope; the Dash0-product-specific skills that were previously on this branch have been moved to a separate repo following review feedback.

## Validation

- Executed for real on AWS App Runner (traces, metrics, and logs flowing)
- All relative links verified; commit follows the conventional format enforced by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)