### PR TITLE
fix: modernize OTTL examples and correct OTel attribute/config staleness

### DIFF
--- a/skills/otel-instrumentation/rules/sdks/dotnet.md
+++ b/skills/otel-instrumentation/rules/sdks/dotnet.md
@@ -46,7 +46,7 @@ All environment variables that control the SDK behavior:
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes | `http://localhost:4318` | OTLP collector endpoint |
 | `OTEL_EXPORTER_OTLP_HEADERS` | No | - | Headers for authentication (e.g., `Authorization=Bearer TOKEN`) |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | No | `http/protobuf` | Protocol: `grpc`, `http/protobuf`, or `http/json` |
-| `OTEL_RESOURCE_ATTRIBUTES` | No | - | Additional resource attributes (e.g., `deployment.environment=production`) |
+| `OTEL_RESOURCE_ATTRIBUTES` | No | - | Additional resource attributes (e.g., `deployment.environment.name=production`) |
 
 **Critical**: Without `OTEL_TRACES_EXPORTER=otlp`, the SDK defaults to `none` and no telemetry is exported.
 

--- a/skills/otel-instrumentation/rules/sdks/go.md
+++ b/skills/otel-instrumentation/rules/sdks/go.md
@@ -50,7 +50,7 @@ All environment variables that control the SDK behavior:
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes | `http://localhost:4317` | OTLP collector endpoint |
 | `OTEL_EXPORTER_OTLP_HEADERS` | No | - | Headers for authentication (e.g., `Authorization=Bearer TOKEN`) |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | No | `grpc` | Protocol: `grpc`, `http/protobuf`, or `http/json` |
-| `OTEL_RESOURCE_ATTRIBUTES` | No | - | Additional resource attributes (e.g., `deployment.environment=production`) |
+| `OTEL_RESOURCE_ATTRIBUTES` | No | - | Additional resource attributes (e.g., `deployment.environment.name=production`) |
 
 **Critical**: The gRPC exporters read these environment variables automatically, but you must initialize the exporters in code for the variables to take effect.
 

--- a/skills/otel-instrumentation/rules/sdks/java.md
+++ b/skills/otel-instrumentation/rules/sdks/java.md
@@ -44,7 +44,7 @@ All environment variables that control the SDK behavior:
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes | `http://localhost:4318` | OTLP collector endpoint |
 | `OTEL_EXPORTER_OTLP_HEADERS` | No | - | Headers for authentication (e.g., `Authorization=Bearer TOKEN`) |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | No | `http/protobuf` | Protocol: `grpc`, `http/protobuf`, or `http/json` |
-| `OTEL_RESOURCE_ATTRIBUTES` | No | - | Additional resource attributes (e.g., `deployment.environment=production`) |
+| `OTEL_RESOURCE_ATTRIBUTES` | No | - | Additional resource attributes (e.g., `deployment.environment.name=production`) |
 
 **Note**: The Java agent defaults all exporters to `otlp` and the protocol to `http/protobuf`.
 

--- a/skills/otel-instrumentation/rules/sdks/nextjs.md
+++ b/skills/otel-instrumentation/rules/sdks/nextjs.md
@@ -91,7 +91,7 @@ export async function register() {
     const resource = resourceFromAttributes({
       [ATTR_SERVICE_NAME]: process.env.OTEL_SERVICE_NAME || 'nextjs-app',
       [ATTR_SERVICE_VERSION]: '1.0.0',
-      'deployment.environment': process.env.NODE_ENV || 'development',
+      'deployment.environment.name': process.env.NODE_ENV || 'development',
     });
 
     // Initialize LoggerProvider for structured logging

--- a/skills/otel-instrumentation/rules/sdks/nodejs.md
+++ b/skills/otel-instrumentation/rules/sdks/nodejs.md
@@ -38,7 +38,7 @@ All environment variables that control the SDK behavior:
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes | `http://localhost:4317` | OTLP collector endpoint |
 | `OTEL_EXPORTER_OTLP_HEADERS` | No | - | Headers for authentication (e.g., `Authorization=Bearer TOKEN`) |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | No | `http/protobuf` when using `auto-instrumentations-node`; `grpc` otherwise | Protocol: `grpc`, `http/protobuf`, or `http/json` |
-| `OTEL_RESOURCE_ATTRIBUTES` | No | - | Additional resource attributes (e.g., `deployment.environment=production`) |
+| `OTEL_RESOURCE_ATTRIBUTES` | No | - | Additional resource attributes (e.g., `deployment.environment.name=production`) |
 
 **Critical**: Without `OTEL_TRACES_EXPORTER=otlp`, the SDK defaults to `none` and no telemetry is exported.
 

--- a/skills/otel-instrumentation/rules/sdks/php.md
+++ b/skills/otel-instrumentation/rules/sdks/php.md
@@ -70,7 +70,7 @@ All environment variables that control the SDK behavior:
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes | `http://localhost:4318` | OTLP collector endpoint |
 | `OTEL_EXPORTER_OTLP_HEADERS` | No | - | Headers for authentication (e.g., `Authorization=Bearer TOKEN`) |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | No | `http/protobuf` | Protocol: `grpc`, `http/protobuf`, or `http/json` |
-| `OTEL_RESOURCE_ATTRIBUTES` | No | - | Additional resource attributes (e.g., `deployment.environment=production`) |
+| `OTEL_RESOURCE_ATTRIBUTES` | No | - | Additional resource attributes (e.g., `deployment.environment.name=production`) |
 
 **Critical**: Without `OTEL_TRACES_EXPORTER=otlp`, the SDK defaults to `none` and no telemetry is exported.
 

--- a/skills/otel-instrumentation/rules/sdks/python.md
+++ b/skills/otel-instrumentation/rules/sdks/python.md
@@ -42,7 +42,7 @@ All environment variables that control the SDK behavior:
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes | `http://localhost:4317` | OTLP collector endpoint |
 | `OTEL_EXPORTER_OTLP_HEADERS` | No | - | Headers for authentication (e.g., `Authorization=Bearer TOKEN`) |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | No | `grpc` | Protocol: `grpc`, `http/protobuf`, or `http/json` |
-| `OTEL_RESOURCE_ATTRIBUTES` | No | - | Additional resource attributes (e.g., `deployment.environment=production`) |
+| `OTEL_RESOURCE_ATTRIBUTES` | No | - | Additional resource attributes (e.g., `deployment.environment.name=production`) |
 
 **Note**: Unlike Node.js, the Python SDK defaults `OTEL_TRACES_EXPORTER` and `OTEL_LOGS_EXPORTER` to `otlp`, so traces and logs are exported without explicitly setting these variables.
 

--- a/skills/otel-instrumentation/rules/sdks/ruby.md
+++ b/skills/otel-instrumentation/rules/sdks/ruby.md
@@ -38,7 +38,7 @@ All environment variables that control the SDK behavior:
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes | `http://localhost:4318` | OTLP collector endpoint |
 | `OTEL_EXPORTER_OTLP_HEADERS` | No | - | Headers for authentication (e.g., `Authorization=Bearer TOKEN`) |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | No | `http/protobuf` | Protocol: `grpc`, `http/protobuf`, or `http/json` |
-| `OTEL_RESOURCE_ATTRIBUTES` | No | - | Additional resource attributes (e.g., `deployment.environment=production`) |
+| `OTEL_RESOURCE_ATTRIBUTES` | No | - | Additional resource attributes (e.g., `deployment.environment.name=production`) |
 
 **Critical**: Without `OTEL_TRACES_EXPORTER=otlp`, the SDK defaults to `none` and no telemetry is exported.
 

--- a/skills/otel-instrumentation/rules/sdks/scala.md
+++ b/skills/otel-instrumentation/rules/sdks/scala.md
@@ -73,7 +73,7 @@ All environment variables that control the SDK behavior:
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes | `http://localhost:4318` | OTLP collector endpoint |
 | `OTEL_EXPORTER_OTLP_HEADERS` | No | - | Headers for authentication (e.g., `Authorization=Bearer TOKEN`) |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | No | `http/protobuf` | Protocol: `grpc`, `http/protobuf`, or `http/json` |
-| `OTEL_RESOURCE_ATTRIBUTES` | No | - | Additional resource attributes (e.g., `deployment.environment=production`) |
+| `OTEL_RESOURCE_ATTRIBUTES` | No | - | Additional resource attributes (e.g., `deployment.environment.name=production`) |
 
 **Note**: The Java agent defaults all exporters to `otlp` and the protocol to `http/protobuf`.
 

--- a/skills/otel-ottl/SKILL.md
+++ b/skills/otel-ottl/SKILL.md
@@ -132,12 +132,12 @@ Occur during telemetry processing:
 
 ### Error mode configuration
 
-Always set `error_mode` explicitly.
+Set `error_mode` explicitly for clarity; `ignore` is the default.
 
 | Mode | Behavior | When to use |
 |------|----------|-------------|
-| `propagate` (default) | Stops processing current item | Development and strict environments where you want to catch every error |
-| `ignore` | Logs error, continues processing | **Production** — set this unless you have a specific reason not to |
+| `ignore` (default) | Logs the error and continues to the next statement | **Production and general use** — the default for the transform and filter processors |
+| `propagate` | Returns the error up the pipeline, dropping the payload from the Collector | Development and strict environments where you want to catch every error |
 | `silent` | Ignores errors without logging | High-volume pipelines with known-safe transforms where error logs are noise |
 
 ```yaml
@@ -145,10 +145,12 @@ processors:
   transform:
     error_mode: ignore
     trace_statements:
-      - context: span
-        statements:
-          - set(span.attributes["parsed"], ParseJSON(span.attributes["json_body"]))
+      - set(span.attributes["parsed"], ParseJSON(span.attributes["json_body"]))
 ```
+
+Statements are a flat list; the Collector infers the context (`span`, `metric`, `datapoint`, `log`, and so on) from the path prefixes.
+Use the object form with an explicit `context:` only when a statement group mixes paths that cannot be inferred to a single context, or when you need a group-level condition or `error_mode`.
+
 ## Performance
 
 Use `where` clauses to skip items early.

--- a/skills/otel-ottl/SKILL.md
+++ b/skills/otel-ottl/SKILL.md
@@ -92,7 +92,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [transform, batch]
+      processors: [transform]
       exporters: [debug]   # swap in production exporter once validated
 ```
 

--- a/skills/otel-ottl/rules/cardinality.md
+++ b/skills/otel-ottl/rules/cardinality.md
@@ -9,12 +9,10 @@ processors:
   transform/normalize-paths:
     error_mode: ignore
     trace_statements:
-      - context: span
-        statements:
-          - replace_pattern(span.attributes["url.path"], "/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", "/{uuid}") where span.attributes["url.path"] != nil
-          - replace_pattern(span.attributes["url.path"], "/\\d+", "/{id}") where span.attributes["url.path"] != nil
-          - replace_pattern(span.attributes["http.route"], "/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", "/{uuid}") where span.attributes["http.route"] != nil
-          - replace_pattern(span.attributes["http.route"], "/\\d+", "/{id}") where span.attributes["http.route"] != nil
+      - replace_pattern(span.attributes["url.path"], "/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", "/{uuid}") where span.attributes["url.path"] != nil
+      - replace_pattern(span.attributes["url.path"], "/\\d+", "/{id}") where span.attributes["url.path"] != nil
+      - replace_pattern(span.attributes["http.route"], "/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", "/{uuid}") where span.attributes["http.route"] != nil
+      - replace_pattern(span.attributes["http.route"], "/\\d+", "/{id}") where span.attributes["http.route"] != nil
 ```
 
 ## Mask IP addresses to subnet
@@ -24,9 +22,7 @@ processors:
   transform/mask-ips:
     error_mode: ignore
     trace_statements:
-      - context: span
-        statements:
-          - replace_pattern(span.attributes["client.address"], "(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})\\.\\d{1,3}", "$$1.0") where span.attributes["client.address"] != nil
+      - replace_pattern(span.attributes["client.address"], "(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})\\.\\d{1,3}", "$$1.0") where span.attributes["client.address"] != nil
     # Add log_statements with the same pattern using log.attributes to apply to logs.
 ```
 
@@ -37,9 +33,7 @@ processors:
   transform/limit-attributes:
     error_mode: ignore
     trace_statements:
-      - context: span
-        statements:
-          - limit(span.attributes, 64, [])
-          - truncate_all(span.attributes, 256)
+      - limit(span.attributes, 64, [])
+      - truncate_all(span.attributes, 256)
     # Add log_statements with the same pattern using log.attributes to apply to logs.
 ```

--- a/skills/otel-ottl/rules/enrichment.md
+++ b/skills/otel-ottl/rules/enrichment.md
@@ -21,7 +21,5 @@ processors:
   transform/copy-resource:
     error_mode: ignore
     trace_statements:
-      - context: span
-        statements:
-          - set(span.attributes["deployment.environment.name"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment.name"] != nil
+      - set(span.attributes["deployment.environment.name"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment.name"] != nil
 ```

--- a/skills/otel-ottl/rules/patterns.md
+++ b/skills/otel-ottl/rules/patterns.md
@@ -52,7 +52,7 @@ processors:
   transform:
     trace_statements:
       - set(span.status.code, STATUS_CODE_ERROR) where span.attributes["http.response.status_code"] >= 500
-      - set(span.attributes["env"], "production") where resource.attributes["deployment.environment"] == "prod"
+      - set(span.attributes["env"], "production") where resource.attributes["deployment.environment.name"] == "prod"
 
 service:
   pipelines:

--- a/skills/otel-ottl/rules/patterns.md
+++ b/skills/otel-ottl/rules/patterns.md
@@ -24,10 +24,8 @@ time_unix_nano < UnixNano(Now()) - 21600000000000
 processors:
   transform:
     log_statements:
-      - context: log
-        statements:
-          - set(log.observed_time, Now()) where log.observed_time_unix_nano == 0
-          - set(log.time, log.observed_time) where log.time_unix_nano == 0
+      - set(log.observed_time, Now()) where log.observed_time_unix_nano == 0
+      - set(log.time, log.observed_time) where log.time_unix_nano == 0
 ```
 
 ## Filter processor example
@@ -35,9 +33,9 @@ processors:
 ```yaml
 processors:
   filter:
-    metrics:
-      datapoint:
-        - 'IsMatch(ConvertCase(String(metric.name), "lower"), "^k8s\\.replicaset\\.")'
+    error_mode: ignore
+    metric_conditions:
+      - 'IsMatch(ConvertCase(String(metric.name), "lower"), "^k8s\\.replicaset\\.")'
 
 service:
   pipelines:
@@ -53,10 +51,8 @@ service:
 processors:
   transform:
     trace_statements:
-      - context: span
-        statements:
-          - set(span.status.code, STATUS_CODE_ERROR) where span.attributes["http.response.status_code"] >= 500
-          - set(span.attributes["env"], "production") where resource.attributes["deployment.environment"] == "prod"
+      - set(span.status.code, STATUS_CODE_ERROR) where span.attributes["http.response.status_code"] >= 500
+      - set(span.attributes["env"], "production") where resource.attributes["deployment.environment"] == "prod"
 
 service:
   pipelines:

--- a/skills/otel-ottl/rules/patterns.md
+++ b/skills/otel-ottl/rules/patterns.md
@@ -41,7 +41,7 @@ service:
   pipelines:
     metrics:
       receivers: [otlp]
-      processors: [filter, batch]
+      processors: [filter]
       exporters: [debug]
 ```
 
@@ -58,7 +58,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [transform, batch]
+      processors: [transform]
       exporters: [debug]
 ```
 

--- a/skills/otel-ottl/rules/redaction.md
+++ b/skills/otel-ottl/rules/redaction.md
@@ -24,11 +24,11 @@ processors:
       - delete_key(span.attributes, "credit-card.number")
     log_statements:
       # Mask — credit card numbers (keep first/last 4 digits)
-      - replace_pattern(log.body["string"], "\\b(\\d{4})\\d{5,11}(\\d{4})\\b", "$$1****$$2")
+      - replace_pattern(log.body.string, "\\b(\\d{4})\\d{5,11}(\\d{4})\\b", "$$1****$$2")
   filter/drop-sensitive-logs:
     error_mode: ignore
     log_conditions:
-      - 'IsMatch(log.body["string"], "(?i)-----BEGIN (RSA |EC )?PRIVATE KEY-----")'
+      - 'IsMatch(log.body.string, "(?i)-----BEGIN (RSA |EC )?PRIVATE KEY-----")'
 ```
 
 Place redaction processors **after** enrichment processors (`resourcedetection`, `k8sattributes`, `resource`) and **before** exporters.

--- a/skills/otel-ottl/rules/redaction.md
+++ b/skills/otel-ottl/rules/redaction.md
@@ -15,25 +15,20 @@ processors:
   transform/redact:
     error_mode: ignore
     trace_statements:
-      - context: span
-        statements:
-          # Replace — auth and session headers
-          - set(span.attributes["http.request.header.authorization"], "REDACTED") where span.attributes["http.request.header.authorization"] != nil
-          - set(span.attributes["http.request.header.cookie"], "REDACTED") where span.attributes["http.request.header.cookie"] != nil
-          # Hash — emails (preserves correlation)
-          - set(span.attributes["user.email"], SHA256(span.attributes["user.email"])) where span.attributes["user.email"] != nil
-          # Delete — attributes that must never be exported
-          - delete_key(span.attributes, "credit-card.number")
+      # Replace — auth and session headers
+      - set(span.attributes["http.request.header.authorization"], "REDACTED") where span.attributes["http.request.header.authorization"] != nil
+      - set(span.attributes["http.request.header.cookie"], "REDACTED") where span.attributes["http.request.header.cookie"] != nil
+      # Hash — emails (preserves correlation)
+      - set(span.attributes["user.email"], SHA256(span.attributes["user.email"])) where span.attributes["user.email"] != nil
+      # Delete — attributes that must never be exported
+      - delete_key(span.attributes, "credit-card.number")
     log_statements:
-      - context: log
-        statements:
-          # Mask — credit card numbers (keep first/last 4 digits)
-          - replace_pattern(log.body["string"], "\\b(\\d{4})\\d{5,11}(\\d{4})\\b", "$$1****$$2")
+      # Mask — credit card numbers (keep first/last 4 digits)
+      - replace_pattern(log.body["string"], "\\b(\\d{4})\\d{5,11}(\\d{4})\\b", "$$1****$$2")
   filter/drop-sensitive-logs:
     error_mode: ignore
-    logs:
-      log_record:
-        - 'IsMatch(log.body["string"], "(?i)-----BEGIN (RSA |EC )?PRIVATE KEY-----")'
+    log_conditions:
+      - 'IsMatch(log.body["string"], "(?i)-----BEGIN (RSA |EC )?PRIVATE KEY-----")'
 ```
 
 Place redaction processors **after** enrichment processors (`resourcedetection`, `k8sattributes`, `resource`) and **before** exporters.


### PR DESCRIPTION
Modernizes the OTTL skill to current Collector syntax and fixes a few correctness bugs.

**otel-ottl**
- Adopt context inference (flat statements/conditions); migrate filter examples
- Correct `error_mode`; the default is `ignore`, not `propagate`
- Fix `log.body["string"]` → `log.body.string` — was silently no-op'ing log redaction
- Drop the `batch` processor from examples (contradicted the otel-collector skill's guidance)

**otel-instrumentation**
- Use `deployment.environment.name` per the semconv rename
