### PR TITLE
Update license from MIT to Apache-2.0

### DIFF
--- a/skills/otel-collector/README.md
+++ b/skills/otel-collector/README.md
@@ -120,4 +120,4 @@ Replace the placeholders with values from your Dash0 account:
 
 ## License
 
-MIT
+Apache-2.0

--- a/skills/otel-collector/SKILL.md
+++ b/skills/otel-collector/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: otel-collector
 description: Expert guidance for configuring and deploying the OpenTelemetry Collector. Use when setting up a Collector pipeline, configuring receivers, exporters, or processors, deploying a Collector to Kubernetes or Docker, or forwarding telemetry to Dash0. Triggers on requests involving collector, pipeline, OTLP receiver, exporter, or Dash0 collector setup.
-license: MIT
+license: Apache-2.0
 metadata:
   author: dash0
   version: '1.0.0'

--- a/skills/otel-instrumentation/README.md
+++ b/skills/otel-instrumentation/README.md
@@ -137,4 +137,4 @@ init({
 
 ## License
 
-MIT
+Apache-2.0

--- a/skills/otel-instrumentation/SKILL.md
+++ b/skills/otel-instrumentation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: 'otel-instrumentation'
 description: Configures trace spans, defines custom metrics, sets up log exporters, and optimizes sampling strategies for OpenTelemetry instrumentation. Use when instrumenting applications with traces, metrics, or logs. Triggers on requests for observability, telemetry, tracing, metrics collection, logging integration, or OTel setup.
-license: MIT
+license: Apache-2.0
 metadata:
   author: dash0
   version: '2.0.0'


### PR DESCRIPTION
## Summary

Update the license declaration for both `otel-collector` and `otel-instrumentation` skills from MIT to Apache-2.0.

## Changes

- Updated `LICENSE` field in `SKILL.md` for both skills from `MIT` to `Apache-2.0`
- Updated license statement in `README.md` for both skills from `MIT` to `Apache-2.0`

## Files modified

- `skills/otel-collector/README.md`
- `skills/otel-collector/SKILL.md`
- `skills/otel-instrumentation/README.md`
- `skills/otel-instrumentation/SKILL.md`

https://claude.ai/code/session_015118AifXbCHfihN1SzWm1c