### PR TITLE
fix(instrumentation): align SKILL quickstart exception handling with spans.md

### DIFF
--- a/skills/otel-instrumentation/SKILL.md
+++ b/skills/otel-instrumentation/SKILL.md
@@ -73,8 +73,16 @@ tracer.startActiveSpan('operation-name', async (span) => {
     span.setStatus({ code: SpanStatusCode.OK });
     return result;
   } catch (err) {
-    span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
-    span.recordException(err);
+    // Record the exception as a structured log record, not span.recordException — see rules/spans.md
+    span.setStatus({ code: SpanStatusCode.ERROR, message: `${err.name}: ${err.message}` });
+    const spanContext = span.spanContext();
+    logger.error('operation-name.failed', {
+      'trace_id': spanContext.traceId,
+      'span_id': spanContext.spanId,
+      'exception.type': err.name,
+      'exception.message': err.message,
+      'exception.stacktrace': err.stack,
+    });
     throw err;
   } finally {
     span.end();


### PR DESCRIPTION
The `otel-instrumentation` SKILL.md quickstart used `span.recordException(err)` in its catch block, which directly contradicts the skill's authoritative guidance in [`rules/spans.md`](skills/otel-instrumentation/rules/spans.md): record exceptions as a **structured log record** (with `trace_id`/`span_id` and `exception.*` attributes), and `span.recordException` is explicitly marked `// BAD` there.

This inconsistency was surfaced while evaluating the Tessl eval scenarios in #13, whose instrumentation rubric correctly penalizes `span.recordException` — our own quickstart would have failed it.

The quickstart now emits a structured exception log with trace correlation and an error-class status message, matching `rules/spans.md`.