### PR TITLE
fix(release): grant the release job contents:write so it can push the version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
+      # write (not read): this job pushes the version-bump and changelog
+      # commits and the release tag back to the branch (main is unprotected),
+      # so github-actions[bot] needs contents write or the push 403s.
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
The `release` job pushes the version-bump + changelog commits and the tag to `main`, but declared `permissions: contents: read` → `github-actions[bot]` got a **403** on `git push` ([release run 30342083581](https://github.com/dash0hq/agent-skills/actions/runs/30342083581), step *Update plugin manifests*, exit 128).

Latent since the workflow was written: the release job was always **skipped** because the operator scenarios failed the matrix. Now that #42 makes quarantined scenarios neutral, the matrix goes green, the job runs, and the push permission gap surfaced. #88 had already decoupled the run from the environment approval gate, so the matrix now runs unattended — this is the last thing between us and a successful publish.

Fix: give the job `contents: write` (`main` is unprotected, so the token scope is the only blocker). Covers the manifest push, the changelog push, and the tag push.