### PR TITLE
feat(evals): dump kind delivery-path state on a telemetry stall

### DIFF
--- a/evals/custom/harness/runner.go
+++ b/evals/custom/harness/runner.go
@@ -20,6 +20,10 @@ import (
 // waiting for the first telemetry.
 const telemetryPollInterval = 100 * time.Millisecond
 
+// diagnoseTimeout bounds the best-effort FixtureHooks.Diagnose dump so a
+// wedged cluster cannot hang the run after a telemetry stall.
+const diagnoseTimeout = 90 * time.Second
+
 // FixtureHooks are the pluggable per-fixture build and run steps. Actual
 // fixtures (and their hooks) arrive with U3; the harness only defines the
 // contract. Both hooks receive the fixture workspace (the temp copy the agent
@@ -34,6 +38,12 @@ type FixtureHooks struct {
 	// at it. At runtime the fixture must only be able to reach the relay
 	// (R21); the composed environment points OTLP at the relay.
 	Run func(ctx context.Context, workdir string, env map[string]string) error
+	// Diagnose is called when telemetry never satisfied the assertion
+	// (ClassAgentTelemetry or ClassAgentAssert), while the fixture is still
+	// up, so it can dump live delivery-path state (pod env, app/collector/
+	// relay logs, events) into the test log for the uploaded evidence. It is
+	// best-effort — it must not fail the run — and optional.
+	Diagnose func(ctx context.Context, class FailureClass, detail string)
 }
 
 // Runner executes scenarios end to end and applies the retry policy.
@@ -243,6 +253,14 @@ func (r *Runner) attempt(t *testing.T, sc Scenario, attemptDir string) attemptOu
 	}
 
 	class, detail := awaitTelemetry(t, ctx, sink, sc.Assert, telemetryTimeout)
+	if class != ClassNone && r.Hooks.Diagnose != nil {
+		// Best-effort delivery-path dump while the fixture is still up. Run on
+		// a fresh bounded context so it works even when the scenario ctx is at
+		// its deadline (the common trigger for a telemetry stall).
+		dctx, cancel := context.WithTimeout(context.Background(), diagnoseTimeout)
+		r.Hooks.Diagnose(dctx, class, detail)
+		cancel()
+	}
 	return finish(class, detail, res.CostUSD, transcript)
 }
 

--- a/evals/custom/scenarios/kindfixture.go
+++ b/evals/custom/scenarios/kindfixture.go
@@ -77,6 +77,12 @@ type KindFixture struct {
 
 	mu       sync.Mutex
 	cleanups []func()
+
+	// Captured by run() for the current attempt so diagnose() can dump the
+	// delivery-path state (namespace resources, relay container logs) after a
+	// telemetry stall, while the cluster is still up.
+	namespace      string
+	relayContainer string
 }
 
 // NewKindFixture returns a KindFixture for the scenario, cleaned up when the
@@ -102,7 +108,7 @@ func NewKindFixture(t testingT, cluster *KindCluster, repoRoot, scenarioID strin
 
 // Hooks returns the harness fixture hooks backed by this KindFixture.
 func (f *KindFixture) Hooks() harness.FixtureHooks {
-	return harness.FixtureHooks{Build: f.build, Run: f.run}
+	return harness.FixtureHooks{Build: f.build, Run: f.run, Diagnose: f.diagnose}
 }
 
 // Close removes every cluster and Docker resource created so far, in
@@ -172,8 +178,10 @@ func (f *KindFixture) run(ctx context.Context, workdir string, env map[string]st
 		return err
 	}
 	f.addCleanup(relay.Close)
+	f.relayContainer = relay.containerName
 
 	namespace := "eval-" + randomSuffix()
+	f.namespace = namespace
 	if err := createRunSecrets(ctx, f.cluster, namespace, runSecretEnv(relay, env)); err != nil {
 		return err
 	}
@@ -193,6 +201,56 @@ func (f *KindFixture) run(ctx context.Context, workdir string, env map[string]st
 	}
 
 	return f.spec.Run(f, ctx, relay, namespace, workdir, env[harness.EnvOTLPToken], env["OTEL_RESOURCE_ATTRIBUTES"])
+}
+
+// diagnose dumps the delivery-path state for the current attempt's namespace
+// into the test log after a telemetry stall (ClassAgentTelemetry) or a wrong-
+// telemetry failure (ClassAgentAssert), so the uploaded evidence shows which
+// hop dropped the telemetry. It is best-effort: every step tolerates errors,
+// because the point is to capture whatever is reachable while the cluster is
+// still up. The flaky operator scenarios are the motivating case — test.id
+// survives the operator's OTEL_RESOURCE_ATTRIBUTES merge locally, yet CI
+// intermittently sees no telemetry — but the dump is scenario-agnostic.
+func (f *KindFixture) diagnose(ctx context.Context, class harness.FailureClass, detail string) {
+	ns := f.namespace
+	if ns == "" {
+		return
+	}
+	f.t.Logf("delivery-stall diagnostic [%s]: %s", class, detail)
+
+	dump := func(label string, args ...string) {
+		out, err := f.cluster.Kubectl(ctx, args...)
+		if err != nil {
+			f.t.Logf("  [%s] kubectl error: %v\n%s", label, err, strings.TrimSpace(out))
+			return
+		}
+		f.t.Logf("  [%s]\n%s", label, strings.TrimSpace(out))
+	}
+
+	// Cluster-side resource state and recent events.
+	dump("resources", "-n", ns, "get", "pods,deployments,opentelemetrycollectors,instrumentations", "-o", "wide")
+	dump("events", "-n", ns, "get", "events", "--sort-by=.lastTimestamp")
+
+	// Per pod: the injected OTEL_RESOURCE_ATTRIBUTES (confirms test.id survived
+	// the operator's env merge) and each container's log tail (did the SDK
+	// initialise and export? did the collector receive and forward?).
+	names, err := f.cluster.Kubectl(ctx, "-n", ns, "get", "pods", "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}")
+	if err != nil {
+		f.t.Logf("  [pods] kubectl error: %v", err)
+	}
+	for _, pod := range strings.Fields(names) {
+		dump("env "+pod, "-n", ns, "get", "pod", pod, "-o", "jsonpath={range .spec.containers[*]}{.name}{\"\\t\"}{range .env[?(@.name=='OTEL_RESOURCE_ATTRIBUTES')]}{.value}{end}{\"\\n\"}{end}")
+		dump("logs "+pod, "-n", ns, "logs", pod, "--all-containers", "--prefix", "--tail=80")
+	}
+
+	// Relay logs: did the collector's export reach the in-network relay at all?
+	if f.relayContainer != "" {
+		if out, err := docker(ctx, "logs", "--tail", "80", f.relayContainer); err == nil {
+			f.t.Logf("  [relay-logs %s]\n%s", f.relayContainer, strings.TrimSpace(out))
+		} else {
+			f.t.Logf("  [relay-logs %s] error: %v", f.relayContainer, err)
+		}
+	}
 }
 
 // runDownwardAPI applies the agent-edited workspace (the pre-instrumented


### PR DESCRIPTION
## Why

The operator kind scenarios (`k8s-deploy-otel-operator`, `k8s-deploy-dash0-operator`, quarantined in #42) fail intermittently in CI with `no telemetry with test.id … reached the sink`, and it **doesn't reproduce locally** (Colima masks the relay-sink hop). Firing them repeatedly in CI tells us nothing; we need to see *which hop* drops the telemetry when it happens.

A faithful local repro (operator `0.120.0` + autoinstrumentation `0.53.0`, the agent's exact `Instrumentation` CR) proved the operator **merges and preserves** the per-run `test.id` in `OTEL_RESOURCE_ATTRIBUTES` (it appends its `k8s.*` after our value). So it's **not** a `test.id`-handling bug — it's a flaky delivery on the `app → collector → relay → sink` path, observable only in CI.

## What

- **`harness`:** add an optional, best-effort `FixtureHooks.Diagnose(ctx, class, detail)` the runner invokes when telemetry never satisfies the assertion (`ClassAgentTelemetry`/`ClassAgentAssert`), on a fresh 90s-bounded context, while the fixture is still up. It cannot fail the run.
- **`KindFixture`:** implement it to dump into the test log (captured in the uploaded evidence): namespace resources + events; **per pod** the injected `OTEL_RESOURCE_ATTRIBUTES` (confirms `test.id` survived injection) and container log tails (did the SDK export? did the collector receive/forward?); and the **relay container logs** (did the export reach the relay?).

The dump is scenario-agnostic — any kind scenario that stalls gets it.