### PR TITLE
ci(evals): add manual workflow_dispatch to re-run the eval matrix (with scenario filter)

### DIFF
--- a/.github/workflows/evals-matrix.yml
+++ b/.github/workflows/evals-matrix.yml
@@ -7,12 +7,15 @@
 # repository secret, not an environment-scoped one, so no environment
 # protection rule (e.g. required reviewers) can gate them on manual approval.
 # In place of that gate, agent-scenarios and kind-scenarios each carry an
-# `if: github.event_name == 'workflow_dispatch'` guard: this workflow only
-# ever runs as a workflow_call from release.yml, which is workflow_dispatch-
-# only, so the guard fails closed against a fork PR, a Dependabot PR, or any
-# other PR-authored trigger reaching the secret. Do not reuse this workflow
-# from anything that runs on `pull_request`; that path (evals-pr.yml) must
-# keep the key environment-scoped, per the secrets policy comment there.
+# `if: github.event_name == 'workflow_dispatch'` guard. This workflow runs
+# only two ways, both reporting event_name == 'workflow_dispatch': as a
+# workflow_call from release.yml (itself workflow_dispatch-only), and as a
+# direct workflow_dispatch a maintainer starts to re-run the matrix (or a
+# scenario subset) without publishing — dispatching requires repo write
+# access. The guard therefore fails closed against a fork PR, a Dependabot
+# PR, or any other PR-authored trigger reaching the secret. Do not reuse this
+# workflow from anything that runs on `pull_request`; that path (evals-pr.yml)
+# keeps the key environment-scoped, per the secrets policy comment there.
 name: Evals matrix
 
 on:
@@ -20,6 +23,11 @@ on:
     inputs:
       ref:
         description: "Git ref (SHA) to check out; empty means the default for the caller's event"
+        required: false
+        type: string
+        default: ""
+      scenarios:
+        description: "Comma-separated scenario IDs to run; empty runs the full matrix"
         required: false
         type: string
         default: ""
@@ -39,6 +47,20 @@ on:
       quarantined:
         description: "JSON array of quarantined scenario IDs included in the matrix"
         value: ${{ jobs.select.outputs.quarantined }}
+  # Direct manual trigger: re-run the matrix (or a scenario subset) on demand,
+  # without cutting a release. Dispatching requires repo write access.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (SHA or branch) to check out; empty uses this workflow's ref"
+        required: false
+        type: string
+        default: ""
+      scenarios:
+        description: "Comma-separated scenario IDs, e.g. k8s-deploy-otel-operator,k8s-deploy-dash0-operator; empty runs the full matrix"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -74,9 +96,13 @@ jobs:
 
       - name: Select every scenario (nightly gate)
         id: select
+        env:
+          SCENARIOS: ${{ inputs.scenarios }}
         run: |
           cd evals/custom
-          go run ./cmd/select-scenarios --gate nightly > /tmp/selection.json
+          args="--gate nightly"
+          [ -n "$SCENARIOS" ] && args="$args --scenarios $SCENARIOS"
+          go run ./cmd/select-scenarios $args > /tmp/selection.json
           cat /tmp/selection.json
           {
             echo "count=$(jq '.count' /tmp/selection.json)"

--- a/evals/custom/cmd/select-scenarios/main.go
+++ b/evals/custom/cmd/select-scenarios/main.go
@@ -76,16 +76,17 @@ func main() {
 	changedFile := flag.String("changed", "", "path to a newline-delimited file of changed repository-relative paths (pr gate only)")
 	baseRef := flag.String("changed-from-git", "", "base ref; changed paths come from git diff --name-only <base>...HEAD (pr gate only)")
 	repoRootFlag := flag.String("repo-root", "", "repository root (default: git rev-parse --show-toplevel)")
+	scenariosFlag := flag.String("scenarios", "", "comma-separated scenario IDs to run (nightly gate only; default: the full matrix)")
 	flag.Parse()
 
-	if err := run(os.Stdout, os.Stderr, *gate, *changedFile, *baseRef, *repoRootFlag); err != nil {
+	if err := run(os.Stdout, os.Stderr, *gate, *changedFile, *baseRef, *repoRootFlag, *scenariosFlag); err != nil {
 		fmt.Fprintf(os.Stderr, "select-scenarios: %v\n", err)
 		os.Exit(1)
 	}
 }
 
 // run resolves the inputs, builds the selection, and writes the JSON output.
-func run(stdout, stderr io.Writer, gate, changedFile, baseRef, root string) error {
+func run(stdout, stderr io.Writer, gate, changedFile, baseRef, root, scenariosCSV string) error {
 	if root == "" {
 		detected, err := repoRoot()
 		if err != nil {
@@ -137,6 +138,14 @@ func run(stdout, stderr io.Writer, gate, changedFile, baseRef, root string) erro
 	if err != nil {
 		return err
 	}
+	if strings.TrimSpace(scenariosCSV) != "" {
+		if gate != gateNightly {
+			return fmt.Errorf("--scenarios is only valid with --gate nightly")
+		}
+		if err := filterToScenarios(out, scenariosCSV); err != nil {
+			return err
+		}
+	}
 	enc := json.NewEncoder(stdout)
 	enc.SetIndent("", "  ")
 	return enc.Encode(out)
@@ -186,6 +195,53 @@ func buildSelection(reg *harness.Registry, gate string, changed, quarantined []s
 		}
 	}
 	return out, nil
+}
+
+// filterToScenarios narrows a nightly selection to the comma-separated IDs in
+// csv, preserving each kept scenario's quarantined flag, and recomputes the
+// counts. An ID that is not in the selection is an error, so a typo fails
+// loudly rather than silently running nothing.
+func filterToScenarios(out *output, csv string) error {
+	want := map[string]bool{}
+	for _, id := range strings.Split(csv, ",") {
+		if id = strings.TrimSpace(id); id != "" {
+			want[id] = true
+		}
+	}
+	if len(want) == 0 {
+		return nil
+	}
+	have := map[string]bool{}
+	for _, sc := range out.Scenarios {
+		have[sc.ID] = true
+	}
+	for id := range want {
+		if !have[id] {
+			return fmt.Errorf("--scenarios: unknown scenario %q (not in the full matrix)", id)
+		}
+	}
+	kept := make([]scenarioOutput, 0, len(want))
+	out.Count, out.KindCount = 0, 0
+	for _, sc := range out.Scenarios {
+		if !want[sc.ID] {
+			continue
+		}
+		kept = append(kept, sc)
+		if sc.RequiresKind {
+			out.KindCount++
+		} else {
+			out.Count++
+		}
+	}
+	out.Scenarios = kept
+	keptQ := make([]string, 0, len(out.Quarantined))
+	for _, id := range out.Quarantined {
+		if want[id] {
+			keptQ = append(keptQ, id)
+		}
+	}
+	out.Quarantined = keptQ
+	return nil
 }
 
 // quarantineFile mirrors the structure of evals/custom/quarantine.yaml.

--- a/evals/custom/cmd/select-scenarios/main_test.go
+++ b/evals/custom/cmd/select-scenarios/main_test.go
@@ -118,7 +118,7 @@ func TestRunWithChangedFileExitsCleanly(t *testing.T) {
 	require.NoError(t, os.WriteFile(changed, []byte("skills/otel-instrumentation/rules/sdks/go.md\n\n"), 0o644))
 
 	var stdout, stderr bytes.Buffer
-	require.NoError(t, run(&stdout, &stderr, gatePR, changed, "", root))
+	require.NoError(t, run(&stdout, &stderr, gatePR, changed, "", root, ""))
 
 	var out output
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &out))
@@ -133,7 +133,7 @@ func TestRunWithChangedFromGitSelectsFromDiff(t *testing.T) {
 	root := gitRepoWithGoRuleChange(t)
 
 	var stdout, stderr bytes.Buffer
-	require.NoError(t, run(&stdout, &stderr, gatePR, "", "HEAD~1", root))
+	require.NoError(t, run(&stdout, &stderr, gatePR, "", "HEAD~1", root, ""))
 
 	var out output
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &out))
@@ -148,7 +148,7 @@ func TestRunWithChangedFromGitBadRefErrors(t *testing.T) {
 	root := gitRepoWithGoRuleChange(t)
 
 	var stdout, stderr bytes.Buffer
-	err := run(&stdout, &stderr, gatePR, "", "no-such-ref", root)
+	err := run(&stdout, &stderr, gatePR, "", "no-such-ref", root, "")
 	require.Error(t, err, "an unresolvable base ref must fail")
 	require.Contains(t, err.Error(), "git diff")
 }
@@ -196,7 +196,7 @@ func TestRunZeroScenarioDiffExitsCleanly(t *testing.T) {
 	require.NoError(t, os.WriteFile(changed, []byte("LICENSE\n"), 0o644))
 
 	var stdout, stderr bytes.Buffer
-	require.NoError(t, run(&stdout, &stderr, gatePR, changed, "", root))
+	require.NoError(t, run(&stdout, &stderr, gatePR, changed, "", root, ""))
 
 	var out output
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &out))
@@ -208,13 +208,13 @@ func TestRunFlagValidation(t *testing.T) {
 	root := testRepoRoot(t)
 	var stdout, stderr bytes.Buffer
 
-	require.Error(t, run(&stdout, &stderr, gatePR, "", "", root),
+	require.Error(t, run(&stdout, &stderr, gatePR, "", "", root, ""),
 		"pr gate requires a changed-paths input")
-	require.Error(t, run(&stdout, &stderr, gatePR, "a", "b", root),
+	require.Error(t, run(&stdout, &stderr, gatePR, "a", "b", root, ""),
 		"--changed and --changed-from-git are mutually exclusive")
-	require.Error(t, run(&stdout, &stderr, gateNightly, "a", "", root),
+	require.Error(t, run(&stdout, &stderr, gateNightly, "a", "", root, ""),
 		"changed inputs are invalid for the nightly gate")
-	require.Error(t, run(&stdout, &stderr, "release", "", "", root),
+	require.Error(t, run(&stdout, &stderr, "release", "", "", root, ""),
 		"unknown gates are rejected")
 }
 
@@ -222,7 +222,7 @@ func TestRunNightlyGate(t *testing.T) {
 	root := testRepoRoot(t)
 
 	var stdout, stderr bytes.Buffer
-	require.NoError(t, run(&stdout, &stderr, gateNightly, "", "", root))
+	require.NoError(t, run(&stdout, &stderr, gateNightly, "", "", root, ""))
 
 	var out output
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &out))


### PR DESCRIPTION
## Why
After #88 removed the nightly, `release.yml` is the **only** trigger for the full eval matrix — so re-running the quarantined operator scenarios (e.g. to capture #113's delivery-stall dump) meant **cutting a release and publishing a version**. That's the wrong tool for debugging.

## What
- **`evals-matrix.yml`:** add a `workflow_dispatch` trigger alongside `workflow_call`. Both report `event_name == 'workflow_dispatch'`, so the existing fail-closed guard on the agent/kind jobs is unchanged; only repo-write maintainers can dispatch. No publish, no version bump.
- **`scenarios` input** (comma-separated) → new `select-scenarios --scenarios` filter (nightly gate only), so a run can target a subset. Unknown IDs error loudly; `--scenarios` with `--gate pr` is rejected.