### PR TITLE
feat(evals): capture the result event's error text in failure details

### DIFF
--- a/evals/custom/harness/agent.go
+++ b/evals/custom/harness/agent.go
@@ -83,6 +83,11 @@ type AgentResult struct {
 	// ResultSubtype carries the subtype of the result event (for example
 	// "success", "error_max_turns", or "error_during_execution").
 	ResultSubtype string
+	// ResultText carries the result field of the result event. On is_error
+	// results this is the CLI's own error message ("Invalid API key", "credit
+	// balance is too low", …) — often the only statement of why the run
+	// failed, since the CLI reports API-side errors under subtype "success".
+	ResultText string
 	// CostUSD carries total_cost_usd from the result event.
 	CostUSD float64
 	// Overloaded is true when API overload markers (429/529, rate limit,
@@ -222,9 +227,9 @@ func classifyAgentRun(res *AgentResult) (FailureClass, string) {
 		// agent's own failure to finish, attributed like the timeout path
 		// (agent-telemetry, since no telemetry could be produced).
 		if isInfraResultSubtype(res.ResultSubtype) {
-			return ClassInfra, fmt.Sprintf("CLI reported an infrastructure error result (subtype %q)", res.ResultSubtype)
+			return ClassInfra, appendResultText(fmt.Sprintf("CLI reported an infrastructure error result (subtype %q)", res.ResultSubtype), res.ResultText)
 		}
-		return ClassAgentTelemetry, fmt.Sprintf("CLI reported an error result before telemetry could be produced (subtype %q)", res.ResultSubtype)
+		return ClassAgentTelemetry, appendResultText(fmt.Sprintf("CLI reported an error result before telemetry could be produced (subtype %q)", res.ResultSubtype), res.ResultText)
 	case !res.SkillLoaded:
 		return ClassInfra, "the plugin did not expose the target skill command in system/init slash_commands; the harness could not load the skill (check --plugin-dir and .claude-plugin/plugin.json)"
 	default:
@@ -294,6 +299,9 @@ func (p *streamParser) feed(line []byte) {
 		if subtype, ok := ev["subtype"].(string); ok {
 			p.res.ResultSubtype = subtype
 		}
+		if text, ok := ev["result"].(string); ok {
+			p.res.ResultText = text
+		}
 	}
 }
 
@@ -328,6 +336,26 @@ var infraResultSubtypeMarkers = []string{
 	"credit",
 	"quota",
 	"billing",
+}
+
+// maxResultTextLen bounds how much of the result event's error text is quoted
+// in a failure detail; the full text stays in the transcript.
+const maxResultTextLen = 300
+
+// appendResultText appends the result event's error text to a failure detail,
+// collapsed to one line and truncated to maxResultTextLen runes. The verdict
+// detail is often the only evidence readable after a CI run, so the CLI's own
+// error message must travel with it rather than stay behind in a transcript
+// file on the runner.
+func appendResultText(detail, text string) string {
+	text = strings.Join(strings.Fields(text), " ")
+	if text == "" {
+		return detail
+	}
+	if runes := []rune(text); len(runes) > maxResultTextLen {
+		text = string(runes[:maxResultTextLen]) + "…"
+	}
+	return detail + ": " + text
 }
 
 // isInfraResultSubtype reports whether an is_error result subtype names an

--- a/evals/custom/harness/agent_test.go
+++ b/evals/custom/harness/agent_test.go
@@ -2,6 +2,7 @@ package harness
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -44,7 +45,7 @@ func TestStreamParserSkillLoadedFromInit(t *testing.T) {
 func TestStreamParserInitAndResult(t *testing.T) {
 	p, res := newParser(SkillInstrumentation)
 	p.feed([]byte(`{"type":"system","subtype":"init","plugin_errors":["skill A failed","skill B failed"]}`))
-	p.feed([]byte(`{"type":"result","subtype":"success","is_error":true,"total_cost_usd":1.25}`))
+	p.feed([]byte(`{"type":"result","subtype":"success","is_error":true,"total_cost_usd":1.25,"result":"Invalid API key · Please run /login"}`))
 	p.feed([]byte(`not json at all`)) // tolerated
 
 	require.True(t, res.SawInit)
@@ -52,6 +53,7 @@ func TestStreamParserInitAndResult(t *testing.T) {
 	require.True(t, res.SawResult)
 	require.True(t, res.IsError)
 	require.InDelta(t, 1.25, res.CostUSD, 1e-9)
+	require.Equal(t, "Invalid API key · Please run /login", res.ResultText)
 }
 
 func TestStreamParserOverloadMarkerInStream(t *testing.T) {
@@ -122,6 +124,42 @@ func TestClassifyAgentRun(t *testing.T) {
 	t.Run("nil result is infra", func(t *testing.T) {
 		class, _ := classifyAgentRun(nil)
 		require.Equal(t, ClassInfra, class)
+	})
+
+	// The result event's error text is the CLI's only statement of why an
+	// is_error run failed; the detail must carry it on both branches.
+	t.Run("is_error detail carries the result text", func(t *testing.T) {
+		res := good()
+		res.IsError = true
+		res.ResultSubtype = "success"
+		res.ResultText = "Invalid API key · Please run /login"
+		class, detail := classifyAgentRun(res)
+		require.Equal(t, ClassAgentTelemetry, class)
+		require.Contains(t, detail, `(subtype "success"): Invalid API key · Please run /login`)
+	})
+	t.Run("infra is_error detail carries the result text", func(t *testing.T) {
+		res := good()
+		res.IsError = true
+		res.ResultSubtype = "error_authentication"
+		res.ResultText = "OAuth token has expired"
+		class, detail := classifyAgentRun(res)
+		require.Equal(t, ClassInfra, class)
+		require.Contains(t, detail, `(subtype "error_authentication"): OAuth token has expired`)
+	})
+}
+
+func TestAppendResultText(t *testing.T) {
+	t.Run("empty text leaves the detail unchanged", func(t *testing.T) {
+		require.Equal(t, "detail", appendResultText("detail", ""))
+		require.Equal(t, "detail", appendResultText("detail", " \n\t "))
+	})
+	t.Run("multi-line text collapses to one line", func(t *testing.T) {
+		require.Equal(t, "detail: line one line two", appendResultText("detail", "line one\n\n  line two\n"))
+	})
+	t.Run("long text truncates to maxResultTextLen runes", func(t *testing.T) {
+		long := strings.Repeat("é", maxResultTextLen+10)
+		got := appendResultText("detail", long)
+		require.Equal(t, "detail: "+strings.Repeat("é", maxResultTextLen)+"…", got)
 	})
 }
 


### PR DESCRIPTION
Eval verdicts now say *why* the agent CLI died, not just that it did. The CLI reports API-side failures (invalid key, drained credit, auth expiry) in the result event's `result` text while keeping subtype `"success"`, so the verdict's subtype-only detail was opaque exactly when it mattered: on dash0hq/agent-skills#115 every scenario failed in seconds with `CLI reported an error result before telemetry could be produced (subtype "success")` and nothing in the CI artifacts named the cause — the transcripts carrying the error text stay in the runner's temp dir and are never uploaded.

The harness now captures that text on `AgentResult.ResultText` and appends it to the failure detail on both the infra and agent-telemetry `is_error` branches, collapsed to one line and truncated to 300 runes so multi-line API errors stay on a single verdict line. The same failure now reads `… (subtype "success"): Invalid API key · Please run /login`.