### PR TITLE
feat(evals): ship failing attempts' transcripts in the CI evidence artifact

### DIFF
--- a/evals/custom/README.md
+++ b/evals/custom/README.md
@@ -13,6 +13,7 @@ A scenario run has 4 moving parts:
 - **Sink** — an in-process `otelsink` (from [opentelemetry-packaging](https://github.com/open-telemetry/opentelemetry-packaging)) on loopback receives everything the relay forwards; per-run isolation rides on a `test.id` resource attribute.
 - **Verdicts** — the harness queries the sink and emits a verdict with a failure class: `infra` (retried up to 3 times, never skill-attributed), `agent-noskill` (no evidence the skill entered context), `agent-build`, `agent-telemetry`, or `agent-assert` (agent-attributable classes retry once).
   Verdict evidence includes the agent transcript and the received telemetry.
+  On failure the harness also copies each attempt's transcript (token-scrubbed) into `$EVAL_VERDICT_DIR/transcripts/<scenario>/<attempt>/`, next to the preserved `agent-workspace/`, so it ships with the uploaded CI evidence artifact.
 
 ## Running locally
 

--- a/evals/custom/harness/runner.go
+++ b/evals/custom/harness/runner.go
@@ -195,10 +195,12 @@ func (r *Runner) attempt(t *testing.T, sc Scenario, attemptDir string) attemptOu
 	env := FixtureEnv(sink, relay, token)
 	finish := func(class FailureClass, detail string, cost float64, transcript string) attemptOutcome {
 		if class != ClassNone {
-			// On any failure, preserve the agent-authored source (scrubbed of
-			// the per-run token) for post-mortem, since the containers and the
-			// workspace temp dir are torn down before they can be inspected.
+			// On any failure, preserve the agent-authored source and the agent
+			// transcript (both scrubbed of the per-run token) for post-mortem,
+			// since the containers and the attempt temp dir are torn down
+			// before they can be inspected.
 			preserveAgentWorkspace(sc.ID, workdir, token)
+			preserveTranscript(sc.ID, attemptDir, token)
 		}
 		return attemptOutcome{
 			class:          class,
@@ -360,6 +362,36 @@ func preserveAgentWorkspace(scenarioID, workdir, token string) {
 		_ = os.WriteFile(out, content, 0o644)
 		return nil
 	})
+}
+
+// preserveTranscript copies the attempt's agent transcript (and its .stderr
+// sibling, when the CLI wrote one) into
+// $EVAL_VERDICT_DIR/transcripts/<scenarioID>/<attempt>/ so the raw
+// stream-json record survives in the uploaded CI evidence. The verdict's
+// transcript_paths point into the test's temp directory, which is removed
+// with the runner — without this copy the CLI's turn-by-turn record and its
+// result event (including any API error text) are unrecoverable after a CI
+// run. The per-run bearer token is scrubbed, matching preserveAgentWorkspace.
+// It is best-effort: any error is ignored, since this is diagnostics only.
+func preserveTranscript(scenarioID, attemptDir, token string) {
+	dir := strings.TrimSpace(os.Getenv("EVAL_VERDICT_DIR"))
+	if dir == "" || attemptDir == "" {
+		return
+	}
+	dest := filepath.Join(dir, "transcripts", scenarioID, filepath.Base(attemptDir))
+	for _, name := range []string{"transcript.jsonl", "transcript.jsonl.stderr"} {
+		content, err := os.ReadFile(filepath.Join(attemptDir, name))
+		if err != nil {
+			continue // transcript may not exist when the CLI never started
+		}
+		if token != "" {
+			content = bytes.ReplaceAll(content, []byte(token), []byte("***"))
+		}
+		if os.MkdirAll(dest, 0o755) != nil {
+			return
+		}
+		_ = os.WriteFile(filepath.Join(dest, name), content, 0o644)
+	}
 }
 
 // telemetryFiles lists the signal JSONL files that exist under the sink

--- a/evals/custom/harness/runner_test.go
+++ b/evals/custom/harness/runner_test.go
@@ -175,6 +175,46 @@ func TestPreserveAgentWorkspaceScrubsToken(t *testing.T) {
 	require.True(t, os.IsNotExist(err), "node_modules must be skipped")
 }
 
+// preserveTranscript must copy the transcript and its stderr sibling into the
+// evidence dir with the per-run token scrubbed, so the uploaded CI artifact
+// carries the CLI's raw output but never the secret.
+func TestPreserveTranscriptScrubsToken(t *testing.T) {
+	attemptDir := filepath.Join(t.TempDir(), "attempt-1")
+	require.NoError(t, os.MkdirAll(attemptDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(attemptDir, "transcript.jsonl"), []byte(`{"result":"Bearer SEKRET-TOKEN-42 rejected"}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(attemptDir, "transcript.jsonl.stderr"), []byte("token SEKRET-TOKEN-42"), 0o644))
+
+	verdictDir := t.TempDir()
+	t.Setenv("EVAL_VERDICT_DIR", verdictDir)
+	preserveTranscript("scn", attemptDir, "SEKRET-TOKEN-42")
+
+	dest := filepath.Join(verdictDir, "transcripts", "scn", "attempt-1")
+	got, err := os.ReadFile(filepath.Join(dest, "transcript.jsonl"))
+	require.NoError(t, err)
+	require.Equal(t, `{"result":"Bearer *** rejected"}`, string(got))
+	got, err = os.ReadFile(filepath.Join(dest, "transcript.jsonl.stderr"))
+	require.NoError(t, err)
+	require.Equal(t, "token ***", string(got))
+}
+
+// A failing run must ship every attempt's transcript into the evidence dir:
+// the verdict's transcript_paths point into the test temp dir, which is gone
+// once the CI runner is torn down.
+func TestRunnerFailureShipsTranscriptsToEvidence(t *testing.T) {
+	stub := testutil.WriteStub(t, testutil.GoodStubBody(string(SkillInstrumentation), goSkillFile(t)))
+	// The span arrives, but without the service.name the assertion demands.
+	r := newRunner(t, stub, sendSpanHooks("GET /checkout", nil))
+	verdictDir := t.TempDir()
+	t.Setenv("EVAL_VERDICT_DIR", verdictDir)
+
+	v := r.Run(t, testScenario())
+
+	require.False(t, v.Passed)
+	for attempt := 1; attempt <= MaxAgentAttempts; attempt++ {
+		require.FileExists(t, filepath.Join(verdictDir, "transcripts", v.ScenarioID, fmt.Sprintf("attempt-%d", attempt), "transcript.jsonl"))
+	}
+}
+
 // Covers harness-level AE4: telemetry arrives without the expected attribute;
 // the verdict fails with class agent-assert and attaches evidence.
 func TestRunnerAssertFailureAttachesEvidence(t *testing.T) {


### PR DESCRIPTION
A failed eval run's agent transcript is now readable from the CI evidence artifact. Until now the verdict's `transcript_paths` pointed into the Go test's temp directory, which vanishes with the runner — on dash0hq/agent-skills#115 every scenario died with an instant CLI error, and the uploaded artifact contained nothing that said why, because the raw stream-json record (and the stderr the CLI wrote next to it) never left the machine.

On any failed attempt the runner now copies `transcript.jsonl` and its `.stderr` sibling into `$EVAL_VERDICT_DIR/transcripts/<scenario>/<attempt>/`, scrubbed of the per-run bearer token, mirroring what `preserveAgentWorkspace` already does for the agent's edits. Each attempt keeps its own directory, so an agent retry does not overwrite the first attempt's record. Passing runs ship nothing extra, keeping green artifacts small.

Complements dash0hq/agent-skills#116, which surfaces the result event's error text in the verdict detail; this PR preserves the full record behind that one-line summary.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

