### PR TITLE
feat: publish the skills as the @dash0/agent-skills npm package

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,16 +1,26 @@
 name: Publish to npm
 
-# Publishes @dash0/agent-skills for an existing release tag. Dispatched by
-# release.yml after the GitHub release is created, and dispatchable by hand
-# to retrofit a tag that was released before npm publishing existed (or to
-# retry a failed publish without re-releasing). Always dispatch (never
-# workflow_call): npm's trusted-publisher check matches the run's entry
-# workflow, so publishes must always enter through this file.
+# Publishes @dash0/agent-skills for an existing release tag. Called as a job
+# by release.yml after the GitHub release is created, and dispatchable by
+# hand to retrofit a tag that was released before npm publishing existed (or
+# to retry a failed publish without re-releasing).
+#
+# Auth is the DASH0_NPMJS_PUBLISH_TOKEN organization secret, NOT OIDC
+# trusted publishing: npm validates the calling workflow's name and allows
+# one trusted publisher per package, so it cannot cover both the
+# workflow_call path (entry: release.yml) and the dispatch path (entry: this
+# file). Provenance still works — it uses the Actions OIDC token
+# independently of how npm authenticates.
 on:
   workflow_dispatch:
     inputs:
       tag:
         description: "Release tag to publish (e.g. v1.3.1)"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
         required: true
         type: string
 
@@ -31,8 +41,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          # npm >= 11.5 (bundled with Node 24) is required for OIDC trusted publishing.
           node-version: 24
+          # Writes an .npmrc that reads the auth token from NODE_AUTH_TOKEN.
           registry-url: https://registry.npmjs.org
 
       - name: Ensure package.json matches the tag
@@ -64,9 +74,9 @@ jobs:
           echo "npm publish exclusions verified: no evals/ or docs/ paths in the pack."
 
       - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.DASH0_NPMJS_PUBLISH_TOKEN }}
         run: |
-          # Authenticates via OIDC trusted publishing (this job's id-token: write
-          # permission); no npm token secret. Requires @dash0/agent-skills on
-          # npmjs.com to have this repository + publish-npm.yml configured as a
-          # trusted publisher. --provenance links the tarball to this run.
+          # --provenance links the tarball to this workflow run via the job's
+          # OIDC id-token; npm auth itself is the organization publish token.
           npm publish --provenance --access public

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,75 @@
+name: Publish to npm
+
+# Publishes @dash0/agent-skills for an existing release tag. Called by
+# release.yml after the GitHub release is created, and dispatchable on its
+# own to retrofit a tag that was released before npm publishing existed
+# (or to retry a failed publish without re-releasing).
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v1.3.1)"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish ${{ inputs.tag }} to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
+
+      - uses: actions/setup-node@v4
+        with:
+          # npm >= 11.5 (bundled with Node 24) is required for OIDC trusted publishing.
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Ensure package.json matches the tag
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if [ ! -f package.json ]; then
+            # Retrofit path: tags cut before the npm package existed carry no
+            # package.json; take the manifest from main. The packed content
+            # (skills/) still comes from the tag checkout.
+            git fetch --depth 1 origin main
+            git checkout FETCH_HEAD -- package.json
+          fi
+          # npm requires bare semver (no leading v).
+          jq ".version = \"${TAG#v}\"" package.json > package.json.tmp
+          mv package.json.tmp package.json
+
+      - name: Verify publish exclusions
+        run: |
+          # R20 for the npm artifact: the package.json `files` allowlist ships only
+          # skills/ (plus README, LICENSE, package.json); fail if the pack would
+          # include evals/ or docs/ paths anyway.
+          leaked=$(npm pack --dry-run --json | jq -r '[.[0].files[].path | select(test("^(evals|docs)/"))] | length')
+          if [ "$leaked" != "0" ]; then
+            npm pack --dry-run
+            echo "::error::npm pack would include evals/ or docs/ paths; fix the package.json files allowlist before releasing"
+            exit 1
+          fi
+          echo "npm publish exclusions verified: no evals/ or docs/ paths in the pack."
+
+      - name: Publish to npm
+        run: |
+          # Authenticates via OIDC trusted publishing (this job's id-token: write
+          # permission); no npm token secret. Requires @dash0/agent-skills on
+          # npmjs.com to have this repository + publish-npm.yml configured as a
+          # trusted publisher. --provenance links the tarball to this run.
+          npm publish --provenance --access public

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,19 +1,16 @@
 name: Publish to npm
 
-# Publishes @dash0/agent-skills for an existing release tag. Called by
-# release.yml after the GitHub release is created, and dispatchable on its
-# own to retrofit a tag that was released before npm publishing existed
-# (or to retry a failed publish without re-releasing).
+# Publishes @dash0/agent-skills for an existing release tag. Dispatched by
+# release.yml after the GitHub release is created, and dispatchable by hand
+# to retrofit a tag that was released before npm publishing existed (or to
+# retry a failed publish without re-releasing). Always dispatch (never
+# workflow_call): npm's trusted-publisher check matches the run's entry
+# workflow, so publishes must always enter through this file.
 on:
   workflow_dispatch:
     inputs:
       tag:
         description: "Release tag to publish (e.g. v1.3.1)"
-        required: true
-        type: string
-  workflow_call:
-    inputs:
-      tag:
         required: true
         type: string
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,11 @@ jobs:
             git add "${manifest}"
           done
 
+          # npm requires bare semver (no leading v).
+          jq ".version = \"${TAG#v}\"" package.json > package.json.tmp
+          mv package.json.tmp package.json
+          git add package.json
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if git diff --cached --quiet; then
@@ -217,6 +222,25 @@ jobs:
             git push origin "HEAD:${GITHUB_REF_NAME}"
           fi
 
+      - uses: actions/setup-node@v4
+        with:
+          # npm >= 11.5 (bundled with Node 24) is required for OIDC trusted publishing.
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify publish exclusions (npm)
+        run: |
+          # R20 for the npm artifact: the package.json `files` allowlist ships only
+          # skills/ (plus README, LICENSE, package.json); fail if the pack would
+          # include evals/ or docs/ paths anyway.
+          leaked=$(npm pack --dry-run --json | jq -r '[.[0].files[].path | select(test("^(evals|docs)/"))] | length')
+          if [ "$leaked" != "0" ]; then
+            npm pack --dry-run
+            echo "::error::npm pack would include evals/ or docs/ paths; fix the package.json files allowlist before releasing"
+            exit 1
+          fi
+          echo "npm publish exclusions verified: no evals/ or docs/ paths in the pack."
+
       - name: Verify publish exclusions
         run: |
           # R20: published artifacts must exclude the eval harness and docs
@@ -255,3 +279,13 @@ jobs:
           gh release create "${TAG}" \
             --title "${TAG}" \
             --generate-notes
+
+      - name: Publish to npm
+        run: |
+          # Runs after the GitHub release so the tag/release stay the source of
+          # truth; a failed npm publish can be retried without re-releasing.
+          # Authenticates via OIDC trusted publishing (the job's id-token: write
+          # permission); no npm token secret. Requires @dash0/agent-skills on
+          # npmjs.com to have this repository + release.yml configured as a
+          # trusted publisher. --provenance links the tarball to this run.
+          npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,14 +74,14 @@ jobs:
       - validate
       - evals
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
     permissions:
       id-token: write
       # write (not read): this job pushes the version-bump and changelog
       # commits and the release tag back to the branch (main is unprotected),
       # so github-actions[bot] needs contents write or the push 403s.
       contents: write
-      # to dispatch publish-npm.yml at the end of the release.
-      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -263,14 +263,16 @@ jobs:
             --title "${TAG}" \
             --generate-notes
 
-      - name: Publish to npm
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          # After the GitHub release so the tag/release stay the source of
-          # truth; a failed publish is retried by re-dispatching with the tag,
-          # without re-releasing. Dispatched rather than workflow_call so
-          # npm's OIDC trusted-publisher check always sees publish-npm.yml as
-          # the entry workflow, on the release and retrofit paths alike.
-          gh workflow run publish-npm.yml -f tag="${TAG}"
+  # After the GitHub release so the tag/release stay the source of truth; a
+  # failed publish is retried by dispatching publish-npm.yml with the tag,
+  # without re-releasing.
+  publish-npm:
+    name: Publish to npm
+    needs: release
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/publish-npm.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,8 @@ jobs:
       - validate
       - evals
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
     permissions:
       id-token: write
       # write (not read): this job pushes the version-bump and changelog
@@ -222,25 +224,6 @@ jobs:
             git push origin "HEAD:${GITHUB_REF_NAME}"
           fi
 
-      - uses: actions/setup-node@v4
-        with:
-          # npm >= 11.5 (bundled with Node 24) is required for OIDC trusted publishing.
-          node-version: 24
-          registry-url: https://registry.npmjs.org
-
-      - name: Verify publish exclusions (npm)
-        run: |
-          # R20 for the npm artifact: the package.json `files` allowlist ships only
-          # skills/ (plus README, LICENSE, package.json); fail if the pack would
-          # include evals/ or docs/ paths anyway.
-          leaked=$(npm pack --dry-run --json | jq -r '[.[0].files[].path | select(test("^(evals|docs)/"))] | length')
-          if [ "$leaked" != "0" ]; then
-            npm pack --dry-run
-            echo "::error::npm pack would include evals/ or docs/ paths; fix the package.json files allowlist before releasing"
-            exit 1
-          fi
-          echo "npm publish exclusions verified: no evals/ or docs/ paths in the pack."
-
       - name: Verify publish exclusions
         run: |
           # R20: published artifacts must exclude the eval harness and docs
@@ -280,12 +263,15 @@ jobs:
             --title "${TAG}" \
             --generate-notes
 
-      - name: Publish to npm
-        run: |
-          # Runs after the GitHub release so the tag/release stay the source of
-          # truth; a failed npm publish can be retried without re-releasing.
-          # Authenticates via OIDC trusted publishing (the job's id-token: write
-          # permission); no npm token secret. Requires @dash0/agent-skills on
-          # npmjs.com to have this repository + release.yml configured as a
-          # trusted publisher. --provenance links the tarball to this run.
-          npm publish --provenance --access public
+  # Runs after the GitHub release so the tag/release stay the source of truth;
+  # a failed npm publish can be retried by dispatching publish-npm.yml with the
+  # tag, without re-releasing.
+  publish-npm:
+    name: Publish to npm
+    needs: release
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/publish-npm.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,14 +74,14 @@ jobs:
       - validate
       - evals
     runs-on: ubuntu-latest
-    outputs:
-      tag: ${{ steps.version.outputs.tag }}
     permissions:
       id-token: write
       # write (not read): this job pushes the version-bump and changelog
       # commits and the release tag back to the branch (main is unprotected),
       # so github-actions[bot] needs contents write or the push 403s.
       contents: write
+      # to dispatch publish-npm.yml at the end of the release.
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -263,15 +263,14 @@ jobs:
             --title "${TAG}" \
             --generate-notes
 
-  # Runs after the GitHub release so the tag/release stay the source of truth;
-  # a failed npm publish can be retried by dispatching publish-npm.yml with the
-  # tag, without re-releasing.
-  publish-npm:
-    name: Publish to npm
-    needs: release
-    permissions:
-      contents: read
-      id-token: write
-    uses: ./.github/workflows/publish-npm.yml
-    with:
-      tag: ${{ needs.release.outputs.tag }}
+      - name: Publish to npm
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          # After the GitHub release so the tag/release stay the source of
+          # truth; a failed publish is retried by re-dispatching with the tag,
+          # without re-releasing. Dispatched rather than workflow_call so
+          # npm's OIDC trusted-publisher check always sees publish-npm.yml as
+          # the entry workflow, on the release and retrofit paths alike.
+          gh workflow run publish-npm.yml -f tag="${TAG}"

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ evals/**/bin/
 evals/custom/fixtures/*/obj/
 evals/custom/fixtures/*/target/
 evals/custom/fixtures/*/vendor/
+
+# npm: the package has no dependencies; a stray npm install must not commit a lockfile.
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ npx skills add https://github.com/dash0hq/agent-skills --skill otel-semantic-con
 
 For tool-specific installation instructions (Claude Code, Cursor, Tessl, and others), see [INSTALL.md](./INSTALL.md).
 
+**Consume programmatically via npm** (for agent runtimes that embed the skills rather than install them into a tool):
+
+```bash
+npm install @dash0/agent-skills
+```
+
+The package ships the `skills/` directory trees verbatim — no code. Resolve a skill's location at runtime, for example:
+
+```js
+const { createRequire } = require("node:module");
+const path = require("node:path");
+
+const pkgJson = createRequire(__filename).resolve("@dash0/agent-skills/package.json");
+const skillDir = path.join(path.dirname(pkgJson), "skills", "otel-instrumentation");
+```
+
 ## How to use
 
 Once installed, skills load automatically and the agent picks them up when a task matches.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,7 +32,8 @@ Verify with:
 npm pack --dry-run
 ```
 
-The release workflow re-checks this and publishes with `npm publish --provenance` via [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers) — no npm token secret; the package's trusted publisher on npmjs.com must point at this repository and `release.yml`.
+The release workflow re-checks this and publishes with `npm publish --provenance`, authenticated with the `DASH0_NPMJS_PUBLISH_TOKEN` organization secret.
+(Not [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers): npm validates the calling workflow's name and allows one trusted publisher per package, which cannot cover both the release path and the manual-dispatch path.)
 The workflow also bumps the `version` field in `package.json` (bare semver, no `v` prefix) alongside the plugin manifests.
 
 The Claude Code plugin, the Cursor plugin, and the Gemini CLI extension install by cloning this repository.
@@ -74,7 +75,7 @@ The flag reads the scenarios from the working tree, which carries them regardles
 4. **Commit changelog** — commits the updated `CHANGELOG.md` to `main`.
 5. **Create tag** — creates and pushes an annotated `vMAJOR.MINOR.PATCH` tag on the changelog commit.
 6. **Create GitHub release** — publishes a release with auto-generated notes from the commit history since the previous tag.
-7. **Publish to npm** — publishes `@dash0/agent-skills` (the `skills/` trees only) to npmjs.com with provenance, authenticated via OIDC trusted publishing. This runs as a separate workflow ([`publish-npm.yml`](./.github/workflows/publish-npm.yml)) that the release dispatches with the new tag; it can also be [dispatched manually](https://github.com/dash0hq/agent-skills/actions/workflows/publish-npm.yml) with any existing tag — to retrofit a release cut before npm publishing existed, or to retry a failed publish without re-releasing. Publishes always enter through `publish-npm.yml`, so npm's trusted-publisher configuration points at that one workflow.
+7. **Publish to npm** — publishes `@dash0/agent-skills` (the `skills/` trees only) to npmjs.com with provenance, authenticated with the `DASH0_NPMJS_PUBLISH_TOKEN` organization secret. This runs as a separate job that calls [`publish-npm.yml`](./.github/workflows/publish-npm.yml) with the new tag; the same workflow can also be [dispatched manually](https://github.com/dash0hq/agent-skills/actions/workflows/publish-npm.yml) with any existing tag — to retrofit a release cut before npm publishing existed, or to retry a failed publish without re-releasing.
 
 ## Post-release verification
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -74,7 +74,7 @@ The flag reads the scenarios from the working tree, which carries them regardles
 4. **Commit changelog** — commits the updated `CHANGELOG.md` to `main`.
 5. **Create tag** — creates and pushes an annotated `vMAJOR.MINOR.PATCH` tag on the changelog commit.
 6. **Create GitHub release** — publishes a release with auto-generated notes from the commit history since the previous tag.
-7. **Publish to npm** — publishes `@dash0/agent-skills` (the `skills/` trees only) to npmjs.com with provenance, authenticated via OIDC trusted publishing.
+7. **Publish to npm** — publishes `@dash0/agent-skills` (the `skills/` trees only) to npmjs.com with provenance, authenticated via OIDC trusted publishing. This runs as a separate workflow ([`publish-npm.yml`](./.github/workflows/publish-npm.yml)) called with the new tag; it can also be [dispatched manually](https://github.com/dash0hq/agent-skills/actions/workflows/publish-npm.yml) with any existing tag — to retrofit a release cut before npm publishing existed, or to retry a failed publish without re-releasing.
 
 ## Post-release verification
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -74,7 +74,7 @@ The flag reads the scenarios from the working tree, which carries them regardles
 4. **Commit changelog** — commits the updated `CHANGELOG.md` to `main`.
 5. **Create tag** — creates and pushes an annotated `vMAJOR.MINOR.PATCH` tag on the changelog commit.
 6. **Create GitHub release** — publishes a release with auto-generated notes from the commit history since the previous tag.
-7. **Publish to npm** — publishes `@dash0/agent-skills` (the `skills/` trees only) to npmjs.com with provenance, authenticated via OIDC trusted publishing. This runs as a separate workflow ([`publish-npm.yml`](./.github/workflows/publish-npm.yml)) called with the new tag; it can also be [dispatched manually](https://github.com/dash0hq/agent-skills/actions/workflows/publish-npm.yml) with any existing tag — to retrofit a release cut before npm publishing existed, or to retry a failed publish without re-releasing.
+7. **Publish to npm** — publishes `@dash0/agent-skills` (the `skills/` trees only) to npmjs.com with provenance, authenticated via OIDC trusted publishing. This runs as a separate workflow ([`publish-npm.yml`](./.github/workflows/publish-npm.yml)) that the release dispatches with the new tag; it can also be [dispatched manually](https://github.com/dash0hq/agent-skills/actions/workflows/publish-npm.yml) with any existing tag — to retrofit a release cut before npm publishing existed, or to retry a failed publish without re-releasing. Publishes always enter through `publish-npm.yml`, so npm's trusted-publisher configuration points at that one workflow.
 
 ## Post-release verification
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,6 +25,16 @@ tessl plugin publish . --dry-run --verbose
 
 The `--verbose` file listing must contain no paths under `evals/` or `docs/`; if it does, fix the ignore files before running the release workflow.
 
+The npm package ([`@dash0/agent-skills`](https://www.npmjs.com/package/@dash0/agent-skills)) excludes them through the `files` allowlist in `package.json`, which ships only `skills/` (plus `README.md`, `LICENSE`, and `package.json`).
+Verify with:
+
+```bash
+npm pack --dry-run
+```
+
+The release workflow re-checks this and publishes with `npm publish --provenance` via [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers) — no npm token secret; the package's trusted publisher on npmjs.com must point at this repository and `release.yml`.
+The workflow also bumps the `version` field in `package.json` (bare semver, no `v` prefix) alongside the plugin manifests.
+
 The Claude Code plugin, the Cursor plugin, and the Gemini CLI extension install by cloning this repository.
 Neither `plugin.json` nor `gemini-extension.json` supports an include or exclude field, and no ignore-file mechanism exists for those installers (verified against the [Claude Code plugin reference](https://code.claude.com/docs/en/plugins-reference) and the [Gemini CLI extension reference](https://github.com/google-gemini/gemini-cli/blob/main/docs/extensions/reference.md) as of 2026-07).
 Those installs therefore contain `evals/` and `docs/`; the content is inert for consumers, and removing it would require a separate distribution repository or release archives instead of git clones.
@@ -64,6 +74,7 @@ The flag reads the scenarios from the working tree, which carries them regardles
 4. **Commit changelog** — commits the updated `CHANGELOG.md` to `main`.
 5. **Create tag** — creates and pushes an annotated `vMAJOR.MINOR.PATCH` tag on the changelog commit.
 6. **Create GitHub release** — publishes a release with auto-generated notes from the commit history since the previous tag.
+7. **Publish to npm** — publishes `@dash0/agent-skills` (the `skills/` trees only) to npmjs.com with provenance, authenticated via OIDC trusted publishing.
 
 ## Post-release verification
 
@@ -72,4 +83,10 @@ The flag reads the scenarios from the working tree, which carries them regardles
 
    ```bash
    npx skills add dash0hq/agent-skills
+   ```
+
+3. Verify the npm package:
+
+   ```bash
+   npm view @dash0/agent-skills version
    ```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+	"name": "@dash0/agent-skills",
+	"version": "1.3.1",
+	"description": "OpenTelemetry skills and reference documentation for AI coding assistants",
+	"license": "Apache-2.0",
+	"author": {
+		"name": "Dash0",
+		"email": "support@dash0.com"
+	},
+	"homepage": "https://github.com/dash0hq/agent-skills",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/dash0hq/agent-skills.git"
+	},
+	"bugs": "https://github.com/dash0hq/agent-skills/issues",
+	"keywords": [
+		"otel",
+		"opentelemetry",
+		"observability",
+		"o11y",
+		"instrumentation",
+		"monitoring",
+		"ai-agent",
+		"skills",
+		"agentic",
+		"engineering",
+		"developer",
+		"coding",
+		"productivity"
+	],
+	"files": [
+		"skills"
+	]
+}


### PR DESCRIPTION
## What

Publishes the four skill trees as an npm package, **`@dash0/agent-skills`**, alongside the existing distribution channels (skills CLI, Claude Code/Cursor plugins, Gemini extension, Tessl):

- Root `package.json` with a `files: ["skills"]` allowlist — the pack ships the `skills/` trees verbatim plus README/LICENSE, no code, no `evals/`, no `docs/` (the R20 exclusion holds by construction; verified locally with `npm pack --dry-run`: 0 leaked paths, ~150 kB tarball). No `exports` map on purpose, so consumers can `require.resolve("@dash0/agent-skills/package.json")` and join subpaths.
- A new reusable workflow, `publish-npm.yml`: verifies the pack contents (mirroring the existing Tessl R20 check) and runs `npm publish --provenance --access public`. It is:
  - **called by `release.yml` after the GitHub release is created**, so the tag/release remain the source of truth;
  - **manually dispatchable with any existing tag** — to retrofit `v1.3.1` (cut before the npm package existed; the dispatch path takes `package.json` from `main` and stamps the tag version onto it, while the packed `skills/` content comes from the tag checkout) or to retry a failed publish without re-releasing.
- `release.yml`: the manifest-bump step also sets `package.json`'s version (bare semver, `v` stripped); the release job exposes the new tag as an output for the npm job.
- Docs: RELEASE.md (artifact contents, workflow steps, post-release verification) and a README section for programmatic consumption.
- `.gitignore`: `package-lock.json` (the package has no dependencies; a stray `npm install` must not commit a lockfile).

## Why

Dash0's Agent0 will embed these skills in its sandboxed coding agent and run A/B evals over them (dash0hq/dash0#16127 and its stacked follow-ups). Consuming via npm gives lockfile pinning with integrity hashes, Renovate updates, and provenance — without vendoring the trees or cloning at build time.


