### PR TITLE
fix(otel-instrumentation): quoted name=value ENV form for NODE_OPTIONS

### DIFF
--- a/evals/custom/README.md
+++ b/evals/custom/README.md
@@ -67,6 +67,9 @@ Complete Go blocks compile against a pinned OpenTelemetry Go SDK dependency set 
 Complete blocks in other languages report `skipped-no-toolchain` too, naming the language, because their fixture-image compilers are a follow-up.
 Fragments are reported in the `code-fragment` category and exempted from compilation, never silently dropped.
 
+`dockerfile` blocks are linted for the `ENV` and `LABEL` `name=value` contract: the legacy space-separated form fails validation because the classic (non-BuildKit) Docker builder rejects values containing spaces at parse time ([issue #120](https://github.com/dash0hq/agent-skills/issues/120)).
+The same check gates every scenario's fixture workspace before `docker build`, so an agent-written Dockerfile using the legacy form fails the attempt even on BuildKit-backed hosts that would accept it.
+
 ## Adding a scenario when adding a rule file
 
 The registry test (`Default().Validate(...)` in [`scenarios/scenarios_test.go`](./scenarios/scenarios_test.go)) fails CI when a rule file is unclassified or a dedicated rule file has no scenario, so this workflow is mandatory:

--- a/evals/custom/examples/block.go
+++ b/evals/custom/examples/block.go
@@ -89,8 +89,12 @@ const (
 	CategoryCodeFragment Category = "code-fragment"
 	// CategoryBash is a shell block, exempt by default (scope boundary).
 	CategoryBash Category = "bash"
+	// CategoryDockerfile is a dockerfile-tagged block, linted for the
+	// ENV/LABEL name=value contract (the legacy space-separated form fails
+	// classic Docker builders — see dockerfile.go).
+	CategoryDockerfile Category = "dockerfile"
 	// CategoryNotValidated is a tagged block with no validator (json, xml,
-	// ini, makefile, dockerfile, html, and so on).
+	// ini, makefile, html, and so on).
 	CategoryNotValidated Category = "not-validated"
 	// CategoryUnclassified is a yaml or untagged block no heuristic
 	// matched; unclassified blocks are validation failures.

--- a/evals/custom/examples/classify.go
+++ b/evals/custom/examples/classify.go
@@ -64,6 +64,8 @@ func Classify(doc *Document) Category {
 	switch b.Tag {
 	case "bash":
 		return CategoryBash
+	case "dockerfile":
+		return CategoryDockerfile
 	case "yaml", "":
 		return classifyYAMLOrUntagged(doc)
 	}

--- a/evals/custom/examples/classify_test.go
+++ b/evals/custom/examples/classify_test.go
@@ -153,6 +153,12 @@ service:
 			content: `{"a": 1}`,
 			want:    CategoryNotValidated,
 		},
+		{
+			name:    "dockerfile tag routes to the dockerfile linter",
+			tag:     "dockerfile",
+			content: "FROM node:22-alpine\nENV NODE_ENV=production\n",
+			want:    CategoryDockerfile,
+		},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/evals/custom/examples/dockerfile.go
+++ b/evals/custom/examples/dockerfile.go
@@ -1,0 +1,177 @@
+package examples
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// The Dockerfile linter guards the ENV/LABEL instruction forms in dockerfile
+// blocks (and, via the scenario build gate, in agent-written Dockerfiles).
+// It exists because of a real regression (issue #120): skill-following agents
+// wrote the legacy space-separated form
+//
+//	ENV NODE_OPTIONS --require @opentelemetry/auto-instrumentations-node/register
+//
+// which BuildKit accepts but the classic builder — still what `docker build`
+// via the Engine API uses on stock GitHub Actions runners — rejects at parse
+// time ("Syntax error - can't find = in ... Must be of the form: name=value")
+// whenever the value contains spaces. The linter is deliberately narrow: it
+// checks only the name=value contract of ENV and LABEL, the one Dockerfile
+// parse rule that differs between builders in a way that broke real builds.
+
+// DockerfileIssue is one problem found in a Dockerfile.
+type DockerfileIssue struct {
+	// Line is the 1-based line the instruction starts on.
+	Line int
+	// Message describes the problem.
+	Message string
+	// BreaksClassicBuilder is true when the instruction fails a real build
+	// on at least one supported builder (the classic builder's name=value
+	// parse rule); false for the deprecated-but-buildable two-token legacy
+	// form.
+	BreaksClassicBuilder bool
+}
+
+func (i DockerfileIssue) String() string {
+	return fmt.Sprintf("line %d: %s", i.Line, i.Message)
+}
+
+// heredocRe matches a heredoc opener token in an instruction, e.g. <<EOF,
+// <<-EOF, or <<"EOF", capturing the delimiter.
+var heredocRe = regexp.MustCompile("<<-?['\"]?([A-Za-z_][A-Za-z0-9_]*)['\"]?")
+
+// LintDockerfile checks every ENV and LABEL instruction in content for the
+// name=value contract and returns one issue per offending instruction.
+func LintDockerfile(content string) []DockerfileIssue {
+	var issues []DockerfileIssue
+	lines := strings.Split(content, "\n")
+	for i := 0; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		// Assemble the logical instruction across backslash continuations,
+		// skipping interleaved comment lines like the Dockerfile parser does.
+		startLine := i + 1
+		logical := lines[i]
+		for strings.HasSuffix(strings.TrimRight(logical, " \t"), "\\") && i+1 < len(lines) {
+			logical = strings.TrimSuffix(strings.TrimRight(logical, " \t"), "\\")
+			i++
+			next := lines[i]
+			if strings.HasPrefix(strings.TrimSpace(next), "#") {
+				continue
+			}
+			logical += " " + next
+		}
+		// Skip heredoc bodies (RUN <<EOF ... EOF): their lines are shell, not
+		// Dockerfile instructions.
+		if m := heredocRe.FindStringSubmatch(logical); m != nil {
+			delimiter := m[1]
+			for i+1 < len(lines) {
+				i++
+				if strings.TrimSpace(lines[i]) == delimiter {
+					break
+				}
+			}
+		}
+		instruction, rest, _ := strings.Cut(strings.TrimSpace(logical), " ")
+		keyword := strings.ToUpper(instruction)
+		if keyword != "ENV" && keyword != "LABEL" {
+			continue
+		}
+		if issue := lintNameVal(keyword, strings.TrimSpace(rest)); issue != nil {
+			issue.Line = startLine
+			issues = append(issues, *issue)
+		}
+	}
+	return issues
+}
+
+// lintNameVal applies the name=value contract to the arguments of one ENV or
+// LABEL instruction. It returns nil when the instruction is well-formed.
+func lintNameVal(keyword, rest string) *DockerfileIssue {
+	words := splitDockerWords(rest)
+	if len(words) == 0 {
+		return &DockerfileIssue{
+			Message:              keyword + " has no arguments",
+			BreaksClassicBuilder: true,
+		}
+	}
+	if strings.Contains(words[0], "=") {
+		// name=value form: every word must be a pair.
+		for _, word := range words {
+			if !strings.Contains(word, "=") {
+				return &DockerfileIssue{
+					Message: fmt.Sprintf(
+						"%s mixes name=value pairs with the bare token %q — every argument must be of the form name=value",
+						keyword, word),
+					BreaksClassicBuilder: true,
+				}
+			}
+		}
+		return nil
+	}
+	// Legacy space-separated form.
+	switch len(words) {
+	case 1:
+		return &DockerfileIssue{
+			Message:              fmt.Sprintf("%s %s has a name but no value", keyword, words[0]),
+			BreaksClassicBuilder: true,
+		}
+	case 2:
+		return &DockerfileIssue{
+			Message: fmt.Sprintf(
+				"%s %s uses the legacy space-separated form; use %s %s=%q instead",
+				keyword, words[0], keyword, words[0], words[1]),
+			BreaksClassicBuilder: false,
+		}
+	default:
+		value := strings.TrimSpace(strings.TrimPrefix(rest, words[0]))
+		return &DockerfileIssue{
+			Message: fmt.Sprintf(
+				"%s %s uses the legacy space-separated form with a value containing spaces; "+
+					"the classic Docker builder rejects it at parse time — use %s %s=%q instead",
+				keyword, words[0], keyword, words[0], value),
+			BreaksClassicBuilder: true,
+		}
+	}
+}
+
+// splitDockerWords splits instruction arguments on unquoted whitespace,
+// keeping quotes and backslash escapes inside the returned words, mirroring
+// the Dockerfile parser's word splitting closely enough for the name=value
+// check.
+func splitDockerWords(s string) []string {
+	var words []string
+	var current strings.Builder
+	inSingle, inDouble, escaped := false, false, false
+	flush := func() {
+		if current.Len() > 0 {
+			words = append(words, current.String())
+			current.Reset()
+		}
+	}
+	for _, r := range s {
+		switch {
+		case escaped:
+			current.WriteRune(r)
+			escaped = false
+		case r == '\\' && !inSingle:
+			current.WriteRune(r)
+			escaped = true
+		case r == '\'' && !inDouble:
+			current.WriteRune(r)
+			inSingle = !inSingle
+		case r == '"' && !inSingle:
+			current.WriteRune(r)
+			inDouble = !inDouble
+		case (r == ' ' || r == '\t') && !inSingle && !inDouble:
+			flush()
+		default:
+			current.WriteRune(r)
+		}
+	}
+	flush()
+	return words
+}

--- a/evals/custom/examples/dockerfile_test.go
+++ b/evals/custom/examples/dockerfile_test.go
@@ -1,0 +1,115 @@
+package examples
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLintDockerfileENVForms(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		// wantMessage is a substring of the single expected issue message;
+		// empty means no issues expected.
+		wantMessage string
+		wantLine    int
+		wantBreaks  bool
+	}{
+		{
+			name:    "quoted name=value form passes",
+			content: "FROM node:22-alpine\nENV NODE_OPTIONS=\"--require @opentelemetry/auto-instrumentations-node/register\"\n",
+		},
+		{
+			name:    "unquoted name=value without spaces passes",
+			content: "FROM node:22-alpine\nENV NODE_ENV=production\n",
+		},
+		{
+			name:    "multiple name=value pairs pass",
+			content: "FROM node:22-alpine\nENV NODE_ENV=production OTEL_TRACES_EXPORTER=otlp\n",
+		},
+		{
+			name:    "name=value pair with quoted spaces passes",
+			content: "FROM node:22-alpine\nENV A=\"b c\" D=e\n",
+		},
+		{
+			name: "issue 120 regression: legacy form with multi-token value breaks classic builders",
+			content: "FROM node:22-alpine\n" +
+				"ENV NODE_OPTIONS --require @opentelemetry/auto-instrumentations-node/register\n",
+			wantMessage: "classic",
+			wantLine:    2,
+			wantBreaks:  true,
+		},
+		{
+			name:        "legacy two-token form is flagged but does not break builds",
+			content:     "FROM node:22-alpine\nENV NODE_ENV production\n",
+			wantMessage: "legacy",
+			wantLine:    2,
+			wantBreaks:  false,
+		},
+		{
+			name:        "mixed pair and bare token breaks",
+			content:     "FROM node:22-alpine\nENV A=1 B\n",
+			wantMessage: "name=value",
+			wantLine:    2,
+			wantBreaks:  true,
+		},
+		{
+			name: "legacy form split over a continuation breaks",
+			content: "FROM node:22-alpine\n" +
+				"ENV NODE_OPTIONS \\\n    --require @opentelemetry/auto-instrumentations-node/register\n",
+			wantMessage: "classic",
+			wantLine:    2,
+			wantBreaks:  true,
+		},
+		{
+			name:        "legacy multi-token LABEL breaks too",
+			content:     "FROM scratch\nLABEL description an example image\n",
+			wantMessage: "classic",
+			wantLine:    2,
+			wantBreaks:  true,
+		},
+		{
+			name:    "comment lines and other instructions are ignored",
+			content: "# ENV NODE_OPTIONS --require pkg\nFROM node:22-alpine\nRUN echo ENV NODE_OPTIONS --require pkg\nCMD [\"node\", \"server.js\"]\n",
+		},
+		{
+			name:    "heredoc bodies are not parsed as instructions",
+			content: "FROM node:22-alpine\nRUN <<EOF\nENV=nonsense but inside a shell script\necho hi\nEOF\nENV NODE_ENV=production\n",
+		},
+		{
+			name:    "lowercase env instruction with valid pair passes",
+			content: "FROM node:22-alpine\nenv NODE_ENV=production\n",
+		},
+		{
+			name:        "lowercase env instruction with legacy multi-token form breaks",
+			content:     "FROM node:22-alpine\nenv NODE_OPTIONS --require pkg/register\n",
+			wantMessage: "classic",
+			wantLine:    2,
+			wantBreaks:  true,
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			issues := LintDockerfile(testCase.content)
+			if testCase.wantMessage == "" {
+				if len(issues) != 0 {
+					t.Fatalf("expected no issues, got %v", issues)
+				}
+				return
+			}
+			if len(issues) != 1 {
+				t.Fatalf("expected 1 issue, got %d: %v", len(issues), issues)
+			}
+			issue := issues[0]
+			if !strings.Contains(issue.Message, testCase.wantMessage) {
+				t.Errorf("message %q does not contain %q", issue.Message, testCase.wantMessage)
+			}
+			if issue.Line != testCase.wantLine {
+				t.Errorf("line: got %d, want %d", issue.Line, testCase.wantLine)
+			}
+			if issue.BreaksClassicBuilder != testCase.wantBreaks {
+				t.Errorf("BreaksClassicBuilder: got %t, want %t", issue.BreaksClassicBuilder, testCase.wantBreaks)
+			}
+		})
+	}
+}

--- a/evals/custom/examples/validate.go
+++ b/evals/custom/examples/validate.go
@@ -149,6 +149,17 @@ func (v *Validator) validateDocument(doc *Document) []*Result {
 		result.Detail = "fragment — not compiled (needs surrounding context; covered by agent scenarios)"
 	case CategoryCodeComplete:
 		v.Code.Validate(result, block.Tag, doc.Content)
+	case CategoryDockerfile:
+		if issues := LintDockerfile(doc.Content); len(issues) > 0 {
+			var details []string
+			for _, issue := range issues {
+				details = append(details, issue.String())
+			}
+			result.Status = StatusFailed
+			result.Detail = "dockerfile: " + strings.Join(details, "; ")
+		} else {
+			result.Status = StatusValidated
+		}
 	case CategoryNotValidated:
 		result.Status = StatusExempt
 		result.Detail = "no validator for tag " + block.Tag

--- a/evals/custom/examples/validate_test.go
+++ b/evals/custom/examples/validate_test.go
@@ -295,6 +295,33 @@ spec:
 	}
 }
 
+func TestValidateDockerfileBlocks(t *testing.T) {
+	// dockerfile blocks are linted, not exempted: the legacy space-separated
+	// ENV form that fails classic Docker builders (issue #120) must fail
+	// validation, and the quoted name=value form must pass. This path needs
+	// no external binary, so a bare Validator suffices.
+	validator := &Validator{}
+	makeDoc := func(content string) *Document {
+		block := &Block{File: "inline.md", Line: 1, Tag: "dockerfile", Content: content}
+		return block.Documents()[0]
+	}
+
+	good := validator.validateDocument(makeDoc(
+		"FROM node:22-alpine\nENV NODE_OPTIONS=\"--require @opentelemetry/auto-instrumentations-node/register\"\n"))
+	if len(good) != 1 || good[0].Status != StatusValidated {
+		t.Fatalf("quoted name=value dockerfile block did not validate: %+v", good[0])
+	}
+
+	bad := validator.validateDocument(makeDoc(
+		"FROM node:22-alpine\nENV NODE_OPTIONS --require @opentelemetry/auto-instrumentations-node/register\n"))
+	if len(bad) != 1 || bad[0].Status != StatusFailed {
+		t.Fatalf("legacy-form dockerfile block did not fail: %+v", bad[0])
+	}
+	if !strings.Contains(bad[0].Detail, "classic") {
+		t.Errorf("failure detail does not explain the classic-builder rejection: %s", bad[0].Detail)
+	}
+}
+
 func TestRenderSummaryHeadlineCounts(t *testing.T) {
 	// The headline counts every status and reports code-complete compiles
 	// and the exempt breakdown, so a green run cannot overstate itself.

--- a/evals/custom/scenarios/docker.go
+++ b/evals/custom/scenarios/docker.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dash0hq/agent-skills/evals/custom/examples"
 	"github.com/dash0hq/agent-skills/evals/custom/harness"
 )
 
@@ -123,6 +124,9 @@ func (d *DockerFixture) addCleanup(f func()) {
 
 // build compiles the fixture workspace into an image tagged per attempt.
 func (d *DockerFixture) build(ctx context.Context, workdir string, _ map[string]string) error {
+	if err := checkClassicBuilderCompatibility(workdir); err != nil {
+		return err
+	}
 	tag := "eval-fixture-" + randomSuffix()
 	if out, err := docker(ctx, "build", "-t", tag, workdir); err != nil {
 		return fmt.Errorf("docker build of the fixture workspace failed: %w\n%s", err, out)
@@ -131,6 +135,55 @@ func (d *DockerFixture) build(ctx context.Context, workdir string, _ map[string]
 	d.mu.Lock()
 	d.currentImage = tag
 	d.mu.Unlock()
+	return nil
+}
+
+// checkClassicBuilderCompatibility scans the workspace for Dockerfiles and
+// rejects instructions that the classic (non-BuildKit) Docker builder fails
+// to parse, most notably the legacy space-separated ENV form with a value
+// containing spaces (issue #120). The harness's own `docker build` runs
+// under BuildKit, which accepts that form, so without this gate an
+// agent-written Dockerfile can pass the eval here yet break `docker build`
+// on stock GitHub Actions runners and other classic-builder CI environments.
+func checkClassicBuilderCompatibility(workdir string) error {
+	var problems []string
+	err := filepath.WalkDir(workdir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		name := d.Name()
+		if d.IsDir() {
+			if name == ".git" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if name != "Dockerfile" && !strings.HasPrefix(name, "Dockerfile.") &&
+			!strings.HasSuffix(strings.ToLower(name), ".dockerfile") {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		relPath, relErr := filepath.Rel(workdir, path)
+		if relErr != nil {
+			relPath = path
+		}
+		for _, issue := range examples.LintDockerfile(string(content)) {
+			if issue.BreaksClassicBuilder {
+				problems = append(problems, fmt.Sprintf("%s:%d: %s", relPath, issue.Line, issue.Message))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("classic-builder compatibility scan of the fixture workspace failed: %w", err)
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("the fixture workspace contains Dockerfile instructions the classic (non-BuildKit) docker builder rejects:\n%s",
+			strings.Join(problems, "\n"))
+	}
 	return nil
 }
 

--- a/evals/custom/scenarios/docker_test.go
+++ b/evals/custom/scenarios/docker_test.go
@@ -2,6 +2,7 @@ package scenarios
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,6 +31,49 @@ func TestFixtureImagesBuild(t *testing.T) {
 			t.Cleanup(func() { _, _ = docker(context.Background(), "rmi", "-f", tag) })
 		})
 	}
+}
+
+// TestClassicBuilderCompatibilityGate verifies the pre-build gate that
+// reproduces the issue #120 regression deterministically: an agent-written
+// Dockerfile using the legacy space-separated ENV form with a multi-token
+// value must fail the attempt even though the harness's BuildKit-backed
+// `docker build` would accept it. The test is hermetic (no Docker needed).
+func TestClassicBuilderCompatibilityGate(t *testing.T) {
+	writeWorkspace := func(t *testing.T, dockerfile string) string {
+		t.Helper()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(dockerfile), 0o644))
+		return dir
+	}
+
+	t.Run("quoted name=value form passes", func(t *testing.T) {
+		dir := writeWorkspace(t, "FROM node:22-alpine\n"+
+			"ENV NODE_OPTIONS=\"--require @opentelemetry/auto-instrumentations-node/register\"\n")
+		require.NoError(t, checkClassicBuilderCompatibility(dir))
+	})
+
+	t.Run("legacy multi-token ENV form fails with file and line", func(t *testing.T) {
+		dir := writeWorkspace(t, "FROM node:22-alpine\n"+
+			"ENV NODE_OPTIONS --require @opentelemetry/auto-instrumentations-node/register\n")
+		err := checkClassicBuilderCompatibility(dir)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Dockerfile:2")
+		require.Contains(t, err.Error(), "classic")
+	})
+
+	t.Run("deprecated two-token legacy form still builds and passes the gate", func(t *testing.T) {
+		dir := writeWorkspace(t, "FROM node:22-alpine\nENV NODE_ENV production\n")
+		require.NoError(t, checkClassicBuilderCompatibility(dir))
+	})
+
+	t.Run("Dockerfiles under node_modules are ignored", func(t *testing.T) {
+		dir := writeWorkspace(t, "FROM node:22-alpine\nENV NODE_ENV=production\n")
+		nested := filepath.Join(dir, "node_modules", "some-pkg")
+		require.NoError(t, os.MkdirAll(nested, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(nested, "Dockerfile"),
+			[]byte("FROM scratch\nENV A --broken value\n"), 0o644))
+		require.NoError(t, checkClassicBuilderCompatibility(dir))
+	})
 }
 
 // TestInfraImagesBuild verifies the relay and helper images build from the

--- a/skills/otel-instrumentation/rules/sdks/nodejs.md
+++ b/skills/otel-instrumentation/rules/sdks/nodejs.md
@@ -74,6 +74,23 @@ export NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/registe
 
 **Note**: Tools like npm, pnpm, and yarn are Node.js applications, so you may observe instrumentation data from package managers when running commands.
 
+#### Dockerfile activation
+
+When activating the SDK in a Dockerfile, set `NODE_OPTIONS` with the `ENV` instruction in the quoted `name=value` form (use `--import` instead of `--require` for ESM projects, per the module system rules below):
+
+```dockerfile
+ENV NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register"
+```
+
+Never write the legacy space-separated `ENV` form.
+The classic (non-BuildKit) Docker builder — still what `docker build` through the Engine API uses, for example on stock GitHub Actions runners — rejects it at parse time whenever the value contains spaces:
+
+```dockerfile
+# BAD: legacy space-separated ENV form — the classic Docker builder fails the build with
+# "Syntax error - can't find = in ... Must be of the form: name=value"
+ENV NODE_OPTIONS --require @opentelemetry/auto-instrumentations-node/register
+```
+
 #### Module system in code snippets
 
 Before writing or copying any Node.js snippet from this file into an application, determine the target file's module system and translate the snippet if needed.


### PR DESCRIPTION
Fixes #120.

The skills-on arm regressed the nodejs scenario: the nodejs rule shows `NODE_OPTIONS` activation only as shell exports, and agents translating that into a Dockerfile wrote the legacy space-separated `ENV` form, which the classic (non-BuildKit) Docker builder rejects at parse time whenever the value contains spaces. Our own eval harness builds fixtures with BuildKit, so it never saw the failure.

Per the issue, this starts from the missing evals and then fixes the content:

- **Example validation**: `dockerfile`-tagged skill blocks are no longer exempt (`not-validated`). A new linter (`evals/custom/examples/dockerfile.go`) enforces the `ENV`/`LABEL` `name=value` contract — legacy multi-token values are flagged as classic-builder-breaking, and the two-token legacy and mixed pair/bare-token forms are flagged too. It handles continuations, comments, quoting, and heredocs.
- **Scenario gate**: `DockerFixture.build` scans the agent-modified workspace for Dockerfiles before `docker build` and fails the attempt on any classic-builder-breaking instruction with `file:line` detail, so this regression class now fails `instr-nodejs-http` (and every other Docker-backed scenario) deterministically even on BuildKit hosts. The harmless two-token form (`ENV NODE_ENV production`) passes the gate — it builds everywhere — while still failing skill-example validation, keeping our own content strictly on the quoted form.
- **Skill fix**: `nodejs.md` gains a "Dockerfile activation" section showing the activation exclusively as `ENV NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register"` (with the ESM `--import` pointer), plus the legacy form as a `# BAD` example with the classic-builder rejection spelled out. The good block is guarded by the new validator category.

No registry changes: `nodejs.md` is already `dedicated` and covered by `instr-nodejs-http`. The pre-existing `dockerfile` block in `otel-collector/rules/custom-distributions.md` passes the new linter.