### PR TITLE
fix(otel-instrumentation): place ENV NODE_OPTIONS after dependency install

### DIFF
--- a/skills/otel-instrumentation/rules/sdks/nodejs.md
+++ b/skills/otel-instrumentation/rules/sdks/nodejs.md
@@ -91,6 +91,24 @@ The classic (non-BuildKit) Docker builder — still what `docker build` through 
 ENV NODE_OPTIONS --require @opentelemetry/auto-instrumentations-node/register
 ```
 
+Place the `ENV NODE_OPTIONS=…` instruction **after** the `RUN` step that installs dependencies.
+`ENV` applies to every subsequent build step, and npm, pnpm, and yarn are themselves Node.js processes — so a `NODE_OPTIONS` that preloads a package which is not installed yet makes the install step itself crash:
+
+```dockerfile
+# BAD: NODE_OPTIONS is set before the dependencies exist, so the npm process
+# crashes with "Error: Cannot find module '@opentelemetry/auto-instrumentations-node/register'"
+ENV NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register"
+COPY package*.json ./
+RUN npm install --omit=dev
+```
+
+```dockerfile
+# GOOD: dependencies are installed first; NODE_OPTIONS only affects later steps and the container runtime
+COPY package*.json ./
+RUN npm install --omit=dev
+ENV NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register"
+```
+
 #### Module system in code snippets
 
 Before writing or copying any Node.js snippet from this file into an application, determine the target file's module system and translate the snippet if needed.


### PR DESCRIPTION
The v1.3.2 "Dockerfile activation" section prescribes the quoted `name=value` `ENV` form but not where the instruction goes. In Agent0's A/B remeasure on 1.3.2, one skill-following agent set `ENV NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register"` before `RUN npm install` — `NODE_OPTIONS` applies to npm's own Node.js process, so the install crashed with `MODULE_NOT_FOUND` on the not-yet-installed preload.

Extend the section with the placement rule (set `NODE_OPTIONS` only after the dependency-install step), a BAD example carrying the exact crash, and a GOOD example showing the ordering. Content-only: unlike #120, the failure is deterministic on every builder, so the existing fixture build gate already catches it.