### PR TITLE
feat(otel-instrumentation): verify dependencies exist before adding or bumping them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,15 @@ updates:
       fixtures:
         patterns:
           - "*"
+    ignore:
+      # python-elasticsearch-service is the upgrade-scenario fixture: it
+      # deliberately pins an old OpenTelemetry release line whose
+      # elasticsearch instrumentation upstream retired, and upgrading past it
+      # is the task under eval. Bumping these pins is doing the scenario's
+      # job for the agent; change them only together with a review of the
+      # scenario's premise (see evals/custom/scenarios/verify_dependencies.go).
+      - dependency-name: "elasticsearch"
+      - dependency-name: "opentelemetry-*"
 
   - package-ecosystem: "maven"
     directories:

--- a/evals/custom/fixtures/README.md
+++ b/evals/custom/fixtures/README.md
@@ -29,6 +29,13 @@ The full contract still applies — the server serves `GET /checkout` backed by 
 
 The contract lint in `evals/scenarios/fixtures_test.go` encodes this list as `browserContractExceptions` and fails when a documented exception disappears from the fixture, so the lint stays at full strength for every fixture.
 
+## Pre-instrumented fixture exception
+
+Most fixtures start from zero so the agent adds instrumentation; a pre-instrumented fixture inverts that for scenarios whose task is changing existing instrumentation (today: the dependency-upgrade scenario, where the fixture pins an OpenTelemetry release line containing a retired instrumentation package).
+Such a fixture follows the full service contract except the "no OpenTelemetry dependencies" clause, and its instrumentation must be zero-code where the language allows it, so the application source stays plain and the dependency manifest plus container command carry the whole instrumentation surface.
+
+The contract lint encodes these fixtures as `preInstrumentedFixtures` in `evals/scenarios/fixtures_test.go`, each entry naming the scenario premise that needs the pre-existing instrumentation; every other lint clause still applies to them.
+
 ## Synthetic data
 
 All fixture data must be obviously synthetic so leaked telemetry can never be mistaken for real customer data.

--- a/evals/custom/fixtures/python-elasticsearch-service/Dockerfile
+++ b/evals/custom/fixtures/python-elasticsearch-service/Dockerfile
@@ -1,0 +1,14 @@
+# Eval fixture: Python HTTP service pre-instrumented with an older
+# OpenTelemetry release line, including the retired elasticsearch
+# instrumentation (see evals/fixtures/README.md, "Pre-instrumented fixture
+# exception", and the upgrade scenario built on this fixture).
+# Deterministic build: pinned base image, pinned dependency versions.
+#
+#   docker build -t python-elasticsearch-service-eval .
+FROM python:3.13-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8080
+CMD ["opentelemetry-instrument", "python", "app.py"]

--- a/evals/custom/fixtures/python-elasticsearch-service/Dockerfile
+++ b/evals/custom/fixtures/python-elasticsearch-service/Dockerfile
@@ -6,6 +6,7 @@
 #
 #   docker build -t python-elasticsearch-service-eval .
 FROM python:3.13-slim
+ENV OTEL_SERVICE_NAME="python-search-service-eval"
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt

--- a/evals/custom/fixtures/python-elasticsearch-service/app.py
+++ b/evals/custom/fixtures/python-elasticsearch-service/app.py
@@ -1,0 +1,60 @@
+# Eval fixture: Python (Flask) HTTP service pre-instrumented through
+# zero-code auto-instrumentation — the dependency pins in requirements.txt
+# and the container command carry the instrumentation; this file stays plain
+# application code (see evals/fixtures/README.md, "Pre-instrumented fixture
+# exception", and the upgrade scenario built on this fixture for why the
+# dependency set is the interesting part). It serves GET /checkout, performs
+# one outbound HTTP call to DOWNSTREAM_URL while handling it, and best-effort
+# indexes the order in Elasticsearch. The Elasticsearch host is synthetic and
+# unreachable at eval time; the indexing call fails fast and is caught, so
+# the service contract is unaffected. Listens on PORT (default 8080) and uses
+# only obviously synthetic data (user@example.test, TEST-0001).
+import logging
+import os
+import urllib.request
+
+from elasticsearch import Elasticsearch
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+logging.basicConfig(level=logging.INFO)
+
+DOWNSTREAM_URL = os.environ.get("DOWNSTREAM_URL", "http://localhost:9090/inventory")
+SEARCH_URL = os.environ.get("SEARCH_URL", "http://search.internal.example.test:9200")
+
+es = Elasticsearch(SEARCH_URL, request_timeout=1, max_retries=0)
+
+
+def index_order(order):
+    # Best-effort search indexing: skipped when Elasticsearch is unreachable.
+    try:
+        es.index(index="orders", id=order["order_id"], document=order)
+    except Exception:
+        app.logger.info("order indexing skipped (Elasticsearch unreachable)")
+
+
+@app.get("/checkout")
+def checkout():
+    with urllib.request.urlopen(DOWNSTREAM_URL, timeout=5) as response:
+        inventory = response.read().decode("utf-8")
+
+    order = dict(
+        order_id="TEST-0001",
+        customer_email="user@example.test",
+        status="confirmed",
+        inventory=inventory,
+    )
+    index_order(order)
+
+    app.logger.info(
+        "checkout completed order.id=%s customer.email=%s",
+        "TEST-0001",
+        "user@example.test",
+    )
+
+    return jsonify(**order)
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", "8080"))
+    app.run(host="0.0.0.0", port=port)

--- a/evals/custom/fixtures/python-elasticsearch-service/requirements.txt
+++ b/evals/custom/fixtures/python-elasticsearch-service/requirements.txt
@@ -1,0 +1,9 @@
+elasticsearch==9.5.0
+flask==3.1.3
+opentelemetry-api==1.43.0
+opentelemetry-distro==0.64b0
+opentelemetry-exporter-otlp==1.43.0
+opentelemetry-instrumentation-elasticsearch==0.64b0
+opentelemetry-instrumentation-flask==0.64b0
+opentelemetry-instrumentation-urllib==0.64b0
+opentelemetry-sdk==1.43.0

--- a/evals/custom/harness/registry.go
+++ b/evals/custom/harness/registry.go
@@ -62,6 +62,7 @@ var defaultRuleClassification = map[string]RuleClassification{
 	"skills/otel-instrumentation/rules/sensitive-data.md":                    {Class: ClassificationShared},
 	"skills/otel-instrumentation/rules/spans.md":                             {Class: ClassificationShared},
 	"skills/otel-instrumentation/rules/telemetry.md":                         {Class: ClassificationShared},
+	"skills/otel-instrumentation/rules/verify-dependencies.md":               {Class: ClassificationShared},
 	"skills/otel-instrumentation/rules/validation.md":                        {Class: ClassificationShared},
 
 	// otel-collector — dedicated: the pipeline file and the 4 deployment

--- a/evals/custom/scenarios/fixtures_test.go
+++ b/evals/custom/scenarios/fixtures_test.go
@@ -17,16 +17,17 @@ import (
 // data) for the contract lint below. Ports supplied through the container
 // command line list the Dockerfile as a source.
 var fixtureSourceFiles = map[string][]string{
-	"evals/custom/fixtures/browser-service": {"server.js", "static/app.js"},
-	"evals/custom/fixtures/dotnet-service":  {"Program.cs"},
-	"evals/custom/fixtures/go-service":      {"main.go"},
-	"evals/custom/fixtures/java-service":    {"src/main/java/checkout/CheckoutServer.java", "src/main/resources/application.properties"},
-	"evals/custom/fixtures/nextjs-service":  {"app/checkout/route.js", "Dockerfile"},
-	"evals/custom/fixtures/nodejs-service":  {"server.js"},
-	"evals/custom/fixtures/php-service":     {"index.php", "Dockerfile"},
-	"evals/custom/fixtures/python-service":  {"app.py"},
-	"evals/custom/fixtures/ruby-service":    {"config.ru", "Dockerfile"},
-	"evals/custom/fixtures/scala-service":   {"src/main/scala/checkout/CheckoutServer.scala"},
+	"evals/custom/fixtures/browser-service":              {"server.js", "static/app.js"},
+	"evals/custom/fixtures/dotnet-service":               {"Program.cs"},
+	"evals/custom/fixtures/go-service":                   {"main.go"},
+	"evals/custom/fixtures/java-service":                 {"src/main/java/checkout/CheckoutServer.java", "src/main/resources/application.properties"},
+	"evals/custom/fixtures/nextjs-service":               {"app/checkout/route.js", "Dockerfile"},
+	"evals/custom/fixtures/nodejs-service":               {"server.js"},
+	"evals/custom/fixtures/php-service":                  {"index.php", "Dockerfile"},
+	"evals/custom/fixtures/python-elasticsearch-service": {"app.py"},
+	"evals/custom/fixtures/python-service":               {"app.py"},
+	"evals/custom/fixtures/ruby-service":                 {"config.ru", "Dockerfile"},
+	"evals/custom/fixtures/scala-service":                {"src/main/scala/checkout/CheckoutServer.scala"},
 }
 
 // nonServiceFixtures lists fixture directories that are not HTTP services and
@@ -36,6 +37,16 @@ var fixtureSourceFiles = map[string][]string{
 var nonServiceFixtures = map[string]string{
 	"evals/custom/fixtures/collector-workspace": "Collector config workspace the agent edits (U5); no service contract",
 	"evals/custom/fixtures/k8s":                 "Kubernetes manifests and workspaces the agent edits (U6); no service contract",
+}
+
+// preInstrumentedFixtures lists service fixtures that deviate from the
+// "no OpenTelemetry dependencies" contract clause because starting already
+// instrumented is their point (see the "Pre-instrumented fixture exception"
+// section of evals/custom/fixtures/README.md): each entry names the scenario
+// premise that needs the pre-existing instrumentation. The rest of the
+// service contract lint still applies to them.
+var preInstrumentedFixtures = map[string]string{
+	"evals/custom/fixtures/python-elasticsearch-service": "upgrade scenario: pre-instrumented on the 0.64b0 line whose elasticsearch instrumentation upstream retired (see verify_dependencies.go)",
 }
 
 // browserContractExceptions documents how the browser fixture deviates from
@@ -114,7 +125,12 @@ func TestFixturesFollowTheContract(t *testing.T) {
 			require.Contains(t, code, "TEST-0001", "synthetic order identifier")
 
 			// The fixture is the code the agent instruments: no file in its
-			// tree may carry an OpenTelemetry dependency of any kind.
+			// tree may carry an OpenTelemetry dependency of any kind — unless
+			// the fixture is documented as pre-instrumented, in which case
+			// the pre-existing instrumentation is the scenario premise.
+			if _, ok := preInstrumentedFixtures[fixture]; ok {
+				return
+			}
 			err = filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
 				if err != nil {
 					return err

--- a/evals/custom/scenarios/scenarios_test.go
+++ b/evals/custom/scenarios/scenarios_test.go
@@ -22,6 +22,7 @@ var allScenarioIDs = []string{
 	NextJSHTTPID, BrowserHTTPID,
 	CollectorPipelineHardeningID, OTTLRedactionID, OTTLEnrichmentID, SemconvAttributesID,
 	K8sDownwardAPIID, K8sOTelOperatorID, K8sHelmChartID, K8sRawManifestsID, K8sDash0OperatorID,
+	PythonRetiredInstrumentationUpgradeID,
 }
 
 // instrumentationSelectable is every otel-instrumentation scenario reachable
@@ -31,6 +32,7 @@ var instrumentationSelectable = []string{
 	PythonHTTPID, JavaHTTPID, RubyHTTPID, PHPHTTPID, ScalaHTTPID,
 	DotnetHTTPID, DotnetNuGetID, DotnetEnrichmentID,
 	NextJSHTTPID, BrowserHTTPID,
+	PythonRetiredInstrumentationUpgradeID,
 }
 
 // The registry completeness test (R17), in both directions: every dedicated

--- a/evals/custom/scenarios/verify_dependencies.go
+++ b/evals/custom/scenarios/verify_dependencies.go
@@ -25,6 +25,10 @@
 // working build; the assertion additionally requires telemetry.sdk.version
 // to have moved off the fixture's pinned 1.43.0, so an agent that changes
 // nothing (or resolves the conflict by staying on the old line) fails.
+// Interactively the rule requires confirming the drop with the user first,
+// because removed instrumentation is telemetry that disappears; this
+// headless run exercises the rule's non-interactive fallback (proceed only
+// because the task cannot complete otherwise, and report the removal).
 package scenarios
 
 import (

--- a/evals/custom/scenarios/verify_dependencies.go
+++ b/evals/custom/scenarios/verify_dependencies.go
@@ -1,0 +1,110 @@
+// The verify-dependencies scenario: exercises the rule that instrumentation
+// packages and versions must be verified against the package registry before
+// being added or bumped, never written from memory
+// (skills/otel-instrumentation/rules/verify-dependencies.md).
+//
+// The fixture is a Python Flask service pre-instrumented with the 1.43.0 /
+// 0.64b0 OpenTelemetry release line, including the elasticsearch
+// instrumentation — which upstream retired at exactly that line: 0.64b0
+// (June 2026) is its last release, it exact-pins
+// opentelemetry-instrumentation==0.64b0, and opentelemetry-bootstrap in the
+// current contrib line no longer maps the elasticsearch package at all. The
+// task is an upgrade to the newest SDK, so every path must confront the
+// retired package, and memory-written bumps fail deterministically at image
+// build time:
+//
+//   - bumping every opentelemetry-instrumentation-* to the current contrib
+//     version includes an elasticsearch release that does not exist on PyPI,
+//     and pip fails with "No matching distribution found";
+//   - bumping the rest while keeping elasticsearch at 0.64b0 trips its exact
+//     pins against the upgraded core packages, and pip fails resolution.
+//
+// An agent following the rule (verify each pin against the registry, notice
+// the retired instrumentation, drop it — falling back to manual
+// instrumentation for the library — and upgrade the remainder) produces a
+// working build; the assertion additionally requires telemetry.sdk.version
+// to have moved off the fixture's pinned 1.43.0, so an agent that changes
+// nothing (or resolves the conflict by staying on the old line) fails.
+package scenarios
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-packaging/testutil/otelsink"
+
+	"github.com/dash0hq/agent-skills/evals/custom/harness"
+)
+
+func init() {
+	registerScenarios(PythonRetiredInstrumentationUpgrade())
+}
+
+// PythonRetiredInstrumentationUpgradeID is the verify-dependencies scenario
+// built around upgrading past the retired Python elasticsearch
+// instrumentation.
+const PythonRetiredInstrumentationUpgradeID = "upgrade-python-retired-instrumentation"
+
+// PythonRetiredServiceName is the service.name the scenario's prompt demands
+// and its assertions check.
+const PythonRetiredServiceName = "python-search-service-eval"
+
+// pythonRetiredFixtureSDKVersion is the opentelemetry-sdk version the fixture
+// pins (the 0.64b0 contrib line). The assertion requires the exported
+// telemetry.sdk.version to differ from it, proving the upgrade happened
+// without hardcoding what "newest" is at eval time.
+const pythonRetiredFixtureSDKVersion = "1.43.0"
+
+// PythonRetiredInstrumentationUpgrade is the verify-dependencies scenario:
+// the fixture's dependency set contains a retired instrumentation package,
+// and only a registry-verified upgrade builds and moves the SDK version.
+func PythonRetiredInstrumentationUpgrade() harness.Scenario {
+	return harness.Scenario{
+		ID:    PythonRetiredInstrumentationUpgradeID,
+		Skill: harness.SkillInstrumentation,
+		RuleFiles: []string{
+			"skills/otel-instrumentation/rules/verify-dependencies.md",
+			"skills/otel-instrumentation/rules/sdks/python.md",
+		},
+		FixturePath: "evals/custom/fixtures/python-elasticsearch-service",
+		Prompt: `The Python Flask HTTP service in the current directory is already instrumented with OpenTelemetry through zero-code auto-instrumentation: the dependencies are pinned in requirements.txt and the container command runs opentelemetry-instrument. Upgrade its OpenTelemetry dependencies to the newest published releases, using the otel-instrumentation skill (dash0-agent-skills:otel-instrumentation).
+
+Upgrade goals:
+- Move to the newest published OpenTelemetry SDK and matching instrumentation releases.
+- After the upgrade the service must still export traces via OTLP over http/protobuf, with the service name "` + PythonRetiredServiceName + `", a server span for the inbound GET /checkout request, and a client span for the outbound HTTP call the handler makes.
+- Keep the application code and its functionality intact.
+` + promptCommonRequirements + `
+- The service runs as the container built by the Dockerfile; make the upgrade take effect there.`,
+		Timeout:          scenarioTimeout,
+		TelemetryTimeout: telemetryTimeout,
+		Assert:           assertUpgradedHTTPTraces(PythonRetiredServiceName, pythonRetiredFixtureSDKVersion),
+	}
+}
+
+// assertUpgradedHTTPTraces wraps assertHTTPTraces and additionally requires
+// the service's spans to carry a telemetry.sdk.version resource attribute
+// different from the fixture's pre-upgrade pin: telemetry that still (or
+// again) reports the old SDK version means the upgrade did not happen.
+func assertUpgradedHTTPTraces(serviceName, oldSDKVersion string) harness.Assertion {
+	httpAssert := assertHTTPTraces(serviceName)
+	return func(t *testing.T, sink *otelsink.Sink) error {
+		if err := httpAssert(t, sink); err != nil {
+			return err
+		}
+		svc := sink.Traces(t).WithResourceAttribute("service.name", serviceName)
+		version := ""
+		for _, sv := range svc.Spans() {
+			version = attrValue(sv.Resource.GetAttributes(), "telemetry.sdk.version")
+			if version != "" {
+				break
+			}
+		}
+		if version == "" {
+			return fmt.Errorf("no telemetry.sdk.version resource attribute on the spans of service.name=%q", serviceName)
+		}
+		if version == oldSDKVersion {
+			return fmt.Errorf("telemetry.sdk.version is still %q, the fixture's pre-upgrade pin: the OpenTelemetry upgrade did not take effect", oldSDKVersion)
+		}
+		return nil
+	}
+}

--- a/skills/otel-instrumentation/SKILL.md
+++ b/skills/otel-instrumentation/SKILL.md
@@ -21,6 +21,7 @@ Expert guidance for implementing high-quality, cost-efficient OpenTelemetry tele
 |-----------------|-------------|
 | [telemetry](./rules/telemetry.md) | **Entrypoint** — signal types, correlation, and navigation |
 | [resolve-values](./rules/resolve-values.md) | Resolving configuration values from the codebase |
+| [verify-dependencies](./rules/verify-dependencies.md) | Verifying instrumentation packages and versions exist before adding them |
 | [resources](./rules/resources.md) | Resource attributes — service identity and environment |
 | [k8s](./rules/platforms/k8s.md) | Kubernetes deployment — downward API, pod spec |
 | [spans](./rules/spans.md) | Spans — naming, kind, status, and hygiene |

--- a/skills/otel-instrumentation/rules/sdks/dotnet.md
+++ b/skills/otel-instrumentation/rules/sdks/dotnet.md
@@ -33,6 +33,16 @@ curl -L -O "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentati
 **Note**: This script is not supported on Apple Silicon.
 For Windows, use the [PowerShell guide](https://opentelemetry.io/docs/zero-code/dotnet/getting-started/).
 
+### Verifying dependencies
+
+Never write a package id or version into a `.csproj` from memory; verify it against NuGet first, per [verify-dependencies](../verify-dependencies.md):
+
+```bash
+dotnet package search OpenTelemetry.Instrumentation.AspNetCore --exact-match
+```
+
+Prefer `dotnet add package <id>` (no version) over hand-editing the project file, so NuGet resolves and records the real latest stable version.
+
 ## Environment variables
 
 All environment variables that control the SDK behavior:

--- a/skills/otel-instrumentation/rules/sdks/go.md
+++ b/skills/otel-instrumentation/rules/sdks/go.md
@@ -37,6 +37,17 @@ Install instrumentation packages for the libraries you use from the [OpenTelemet
 
 **Note**: Installing the packages alone is insufficient—you must write initialization code to activate the SDK AND enable exporters.
 
+### Verifying dependencies
+
+Never hand-write a `require` line in `go.mod` with a version from memory; verify the module against the module proxy first, per [verify-dependencies](../verify-dependencies.md):
+
+```bash
+go list -m -versions go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
+```
+
+The module proxy lists every published version; a module it does not know is not a published instrumentation.
+Add modules with `go get <module>@latest` followed by `go mod tidy`, which resolves real versions and prunes the manifest.
+
 ## Environment variables
 
 All environment variables that control the SDK behavior:

--- a/skills/otel-instrumentation/rules/sdks/java.md
+++ b/skills/otel-instrumentation/rules/sdks/java.md
@@ -31,6 +31,15 @@ wget "https://github.com/open-telemetry/opentelemetry-java-instrumentation/relea
 
 **Note**: The javaagent.jar contains both the agent and instrumentation libraries, enabling automatic instrumentation without modifying source code.
 
+### Verifying dependencies
+
+The javaagent needs no per-library coordinates; prefer it over adding instrumentation libraries to the build.
+When you do add library coordinates, never write a version from memory; verify the coordinate resolves from Maven Central first, per [verify-dependencies](../verify-dependencies.md), and prefer importing the OpenTelemetry BOM at a verified version so per-artifact versions can be omitted:
+
+```bash
+mvn dependency:get -Dartifact=io.opentelemetry:opentelemetry-bom:1.51.0 -Dpackaging=pom
+```
+
 ## Environment variables
 
 All environment variables that control the SDK behavior:

--- a/skills/otel-instrumentation/rules/sdks/nextjs.md
+++ b/skills/otel-instrumentation/rules/sdks/nextjs.md
@@ -22,6 +22,10 @@ Full-stack OpenTelemetry setup for Next.js 13+ with App Router. Server-side uses
   - In Dash0: [Settings → Auth Tokens → Create Token](https://app.dash0.com/settings/auth-tokens)
   - For browser telemetry, use a token with limited permissions (Ingesting only)
 
+## Verifying dependencies
+
+Never write a package name or version into `package.json` from memory; verify it against the npm registry first (`npm view <pkg> version`, `npm view <pkg> deprecated`), per [verify-dependencies](../verify-dependencies.md), and prefer `npm install <pkg>` (no version) so npm resolves the real latest version.
+
 ## Quick Start
 
 ### 1. Install Packages

--- a/skills/otel-instrumentation/rules/sdks/nodejs.md
+++ b/skills/otel-instrumentation/rules/sdks/nodejs.md
@@ -25,6 +25,19 @@ npm install @opentelemetry/auto-instrumentations-node
 
 **Note**: Installing the package alone is insufficient—you must activate the SDK AND enable exporters.
 
+### Verifying dependencies
+
+Never write a package name or version into `package.json` from memory; verify it against the npm registry first, per [verify-dependencies](../verify-dependencies.md):
+
+```bash
+npm view @opentelemetry/instrumentation-undici version         # latest published version
+npm view @opentelemetry/instrumentation-undici versions --json # every published version
+npm view @opentelemetry/instrumentation-undici deprecated      # prints the notice when deprecated, nothing otherwise
+```
+
+A range that matches no published version prints nothing: `npm view '<pkg>@^1.2.3' version`.
+Prefer `npm install <pkg>` (no version) over hand-editing `package.json`, so npm resolves and records the real latest version.
+
 ## Environment variables
 
 All environment variables that control the SDK behavior:

--- a/skills/otel-instrumentation/rules/sdks/php.md
+++ b/skills/otel-instrumentation/rules/sdks/php.md
@@ -56,6 +56,16 @@ Set the `OTEL_PHP_AUTOLOAD_ENABLED` environment variable to `true` so the SDK au
 
 **Note**: Installing the packages and extension alone is insufficient—you must enable auto-loading AND configure exporters.
 
+### Verifying dependencies
+
+Never write a package name or version into `composer.json` from memory; verify it against Packagist first, per [verify-dependencies](../verify-dependencies.md):
+
+```bash
+composer show --available open-telemetry/opentelemetry-auto-slim
+```
+
+Prefer `composer require <pkg>` (no version) over hand-editing `composer.json`, so Composer resolves the real latest version.
+
 ## Environment variables
 
 All environment variables that control the SDK behavior:

--- a/skills/otel-instrumentation/rules/sdks/python.md
+++ b/skills/otel-instrumentation/rules/sdks/python.md
@@ -29,6 +29,19 @@ The `opentelemetry-bootstrap` command detects installed libraries and installs t
 
 **Note**: Installing the packages alone is insufficient—you must activate the SDK AND configure exporters.
 
+### Verifying dependencies
+
+Never write an `opentelemetry-instrumentation-*` package or version into `requirements.txt` (or `pyproject.toml`) from memory; verify it first, per [verify-dependencies](../verify-dependencies.md).
+`opentelemetry-bootstrap` is the authoritative check: it lists only the instrumentation packages the installed contrib release ships, matched against the libraries present in the environment.
+
+```bash
+opentelemetry-bootstrap             # prints package==version for every detected library
+pip index versions opentelemetry-instrumentation-flask  # existence and published versions
+```
+
+A library missing from the bootstrap output has no current instrumentation — retired instrumentations (such as elasticsearch) still install from PyPI at their last release but are no longer maintained or shipped.
+Do not hand-pin such a package; instrument the library manually instead.
+
 ## Environment variables
 
 All environment variables that control the SDK behavior:

--- a/skills/otel-instrumentation/rules/sdks/ruby.md
+++ b/skills/otel-instrumentation/rules/sdks/ruby.md
@@ -25,6 +25,16 @@ bundle add opentelemetry-sdk opentelemetry-instrumentation-all opentelemetry-exp
 
 **Note**: Installing the gems alone is insufficient—you must initialize the SDK AND enable exporters.
 
+### Verifying dependencies
+
+Never write a gem name or version into the `Gemfile` from memory; verify it against RubyGems first, per [verify-dependencies](../verify-dependencies.md):
+
+```bash
+gem info --remote opentelemetry-instrumentation-rails
+```
+
+Prefer `bundle add <gem>` (no version) over hand-editing the `Gemfile`, so Bundler resolves the real latest version.
+
 ## Environment variables
 
 All environment variables that control the SDK behavior:

--- a/skills/otel-instrumentation/rules/sdks/scala.md
+++ b/skills/otel-instrumentation/rules/sdks/scala.md
@@ -60,6 +60,15 @@ libraryDependencies += "io.opentelemetry" % "opentelemetry-api" % "<version>"
 
 Find the current version at [Maven Central — opentelemetry-api](https://central.sonatype.com/artifact/io.opentelemetry/opentelemetry-api).
 
+### Verifying dependencies
+
+Never fill a `<version>` placeholder in `build.sbt` from memory; verify the coordinate and version exist on Maven Central first, per [verify-dependencies](../verify-dependencies.md).
+Look the artifact up on [Maven Central](https://central.sonatype.com/) (as the links above do), or verify resolution from the command line with Coursier, which sbt uses internally:
+
+```bash
+cs resolve io.opentelemetry:opentelemetry-api:1.51.0
+```
+
 ## Environment variables
 
 All environment variables that control the SDK behavior:

--- a/skills/otel-instrumentation/rules/verify-dependencies.md
+++ b/skills/otel-instrumentation/rules/verify-dependencies.md
@@ -1,0 +1,48 @@
+# Verifying instrumentation dependencies
+
+Never write an instrumentation package name or version from memory.
+Knowledge of package ecosystems goes stale in both directions: versions get invented that were never published, and packages that once existed get retired with no further releases.
+A retired package still installs from the registry at its last release, so a successful install alone does not prove the instrumentation is current.
+
+Before adding any instrumentation dependency to a manifest, verify all three against the package registry:
+
+1. **Existence** — the package name is real.
+2. **Version** — the exact version or range you reference has been published.
+3. **Currency** — the package is not deprecated, yanked, or retired, and has a release compatible with the SDK version you target.
+
+## Decision process
+
+1. Prefer the package manager's add command without a version (`npm install <pkg>`, `go get <module>@latest`, `pip install <pkg>`, `bundle add <gem>`, `composer require <pkg>`, `dotnet add package <id>`).
+   It resolves the latest published version from the registry and fails loudly when the package does not exist.
+2. When you must write a manifest entry by hand, first run the lookup command from your language's section (indexed below) and copy the version it reports.
+3. When the lookup shows the package is deprecated, yanked, or has no recent release, do not add it: fall back to the auto-instrumentation path or manual instrumentation per the language's SDK rule, and state why.
+4. When the lookup finds no package at all, do not invent a name: check the [OpenTelemetry registry](https://opentelemetry.io/ecosystem/registry/) for the library, and if nothing current exists, instrument manually per [spans](./spans.md) and the SDK rule.
+5. Never guess a version to complete a manifest entry.
+   A wrong pin fails the build (`npm error notarget`, `go: no matching versions`), or worse, resolves to an incompatible release.
+
+<!-- eval:bad -->
+```json
+{
+  "dependencies": {
+    "@opentelemetry/instrumentation-undici": "^0.57.0"
+  }
+}
+```
+
+The version above was written from memory; no `0.57.x` release of that package was ever published, and `npm install` fails with `npm error code ETARGET`.
+
+## Language-specific verification commands
+
+Each SDK rule carries a "Verifying dependencies" section with the concrete lookup commands for its ecosystem:
+
+- [nodejs](./sdks/nodejs.md#verifying-dependencies) — npm
+- [nextjs](./sdks/nextjs.md#verifying-dependencies) — npm
+- [python](./sdks/python.md#verifying-dependencies) — pip and `opentelemetry-bootstrap`
+- [go](./sdks/go.md#verifying-dependencies) — the Go module proxy
+- [java](./sdks/java.md#verifying-dependencies) — Maven Central
+- [scala](./sdks/scala.md#verifying-dependencies) — Maven Central via sbt/Coursier
+- [dotnet](./sdks/dotnet.md#verifying-dependencies) — NuGet
+- [ruby](./sdks/ruby.md#verifying-dependencies) — RubyGems
+- [php](./sdks/php.md#verifying-dependencies) — Packagist
+
+`browser` does not have dedicated guidance, as all the instrumentation is integrated in the Dash0 Web SDK.

--- a/skills/otel-instrumentation/rules/verify-dependencies.md
+++ b/skills/otel-instrumentation/rules/verify-dependencies.md
@@ -16,6 +16,7 @@ Before adding any instrumentation dependency to a manifest, verify all three aga
    It resolves the latest published version from the registry and fails loudly when the package does not exist.
 2. When you must write a manifest entry by hand, first run the lookup command from your language's section (indexed below) and copy the version it reports.
 3. When the lookup shows the package is deprecated, yanked, or has no recent release, do not add it: fall back to the auto-instrumentation path or manual instrumentation per the language's SDK rule, and state why.
+   When this means removing a dependency that is already in the manifest, follow [Dropping an existing dependency](#dropping-an-existing-dependency).
 4. When the lookup finds no package at all, do not invent a name: check the [OpenTelemetry registry](https://opentelemetry.io/ecosystem/registry/) for the library, and if nothing current exists, instrument manually per [spans](./spans.md) and the SDK rule.
 5. Never guess a version to complete a manifest entry.
    A wrong pin fails the build (`npm error notarget`, `go: no matching versions`), or worse, resolves to an incompatible release.
@@ -30,6 +31,19 @@ Before adding any instrumentation dependency to a manifest, verify all three aga
 ```
 
 The version above was written from memory; no `0.57.x` release of that package was ever published, and `npm install` fails with `npm error code ETARGET`.
+
+## Dropping an existing dependency
+
+Removing an instrumentation dependency makes the telemetry it produced disappear, and dashboards and alerts may be built on that telemetry.
+When an existing instrumentation dependency cannot survive a change — it is retired and blocks an upgrade, or its pins conflict with the rest of the dependency set — do not drop it silently.
+
+Ask the user for confirmation before removing it, naming:
+
+1. The package, and why it cannot be kept.
+2. Exactly which telemetry disappears: the library whose spans, metrics, or logs stop being produced.
+3. The replacement, if any — native client telemetry or manual instrumentation per the language's SDK rule — and any span names or attributes that change with it, since renamed telemetry breaks dashboards and alerts just like removed telemetry.
+
+When you have no way to ask — running non-interactively or in a pipeline — proceed only if the task cannot complete otherwise, and report the removal and its telemetry impact prominently in your summary.
 
 ## Language-specific verification commands
 


### PR DESCRIPTION
Agents writing instrumentation dependencies from memory fail in two ways, both observed in Agent0's A/B evals and in the wild: versions that were never published (`@opentelemetry/instrumentation-undici@^0.57.x`, npm `ETARGET` at install — dash0hq/dash0's eval baseline hits this repeatedly), and packages that once existed but have been **retired** with no further releases (the Python elasticsearch instrumentation, retired after `0.64b0`). The latter is the subtle one: a retired package still installs from the registry at its last release, so a successful install proves nothing about currency.

Following the eval-first pattern of #122:

- **New scenario `upgrade-python-retired-instrumentation`**: a Flask fixture pre-instrumented on the 1.43.0/0.64b0 line *including* the retired elasticsearch instrumentation, prompted to upgrade to the newest SDK — so every path must confront the retired package. Memory-written bumps fail deterministically at image build (a bumped elasticsearch pin does not exist on PyPI; keeping it trips its exact pins against the upgraded core), and the assertion additionally requires `telemetry.sdk.version` to move off the fixture pin, so a no-op or stay-on-the-old-line resolution fails too. Both traps and the rule-following path are container-verified.
- **Pre-instrumented fixture exception**: a new documented contract-lint class (`preInstrumentedFixtures`) inverts the no-OpenTelemetry clause when existing instrumentation is the scenario premise; every other clause still applies. Dependabot ignores the fixture's `elasticsearch` and `opentelemetry-*` pins — bumping them would do the scenario's job for the agent.
- **New shared rule [`verify-dependencies`](skills/otel-instrumentation/rules/verify-dependencies.md)**: never write a package name or version from memory; verify **existence**, **version**, and **currency** against the registry, preferring the package manager's add command over hand-edited manifests. Each SDK rule gains a language-specific "Verifying dependencies" section with the concrete lookup commands (`npm view`, `opentelemetry-bootstrap` + `pip index`, `go list -m -versions`, Maven Central + BOM, Coursier, NuGet search, `gem info`, `composer show`), indexed from the shared rule.