### PR TITLE
ci(release): split post-release steps into parallel dispatchable workflows

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,51 @@
+name: Deploy GitHub Pages
+
+# Deploys the repository as a Jekyll site to GitHub Pages for an existing
+# release tag. Dispatched by release.yml after the GitHub release is created,
+# and dispatchable by hand to retry a failed deployment without re-releasing.
+#
+# Prerequisite: enable Pages in the repository settings with "GitHub Actions"
+# as the source (Settings > Pages > Build and deployment > Source). GitHub
+# creates the github-pages environment automatically on the first deployment.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to deploy (e.g. v1.3.1)"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  deploy:
+    name: Deploy ${{ inputs.tag }} to GitHub Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,10 +77,6 @@ jobs:
     outputs:
       tag: ${{ steps.version.outputs.tag }}
     permissions:
-      id-token: write
-      # write (not read): this job pushes the version-bump and changelog
-      # commits and the release tag back to the branch (main is unprotected),
-      # so github-actions[bot] needs contents write or the push 403s.
       contents: write
     steps:
       - name: Checkout
@@ -90,10 +86,6 @@ jobs:
           # top of it and pushed to the dispatched branch explicitly.
           ref: ${{ needs.resolve.outputs.sha }}
           fetch-depth: 0
-
-      - uses: tesslio/setup-tessl@v2
-        with:
-          token: ${{ secrets.TESSL_TOKEN }}
 
       - name: Compute next version
         id: version
@@ -139,7 +131,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if git diff --cached --quiet; then
-            echo "plugin manifests unchanged, skipping commit."
+            echo "Plugin manifests unchanged, skipping commit."
           else
             git commit -m "chore: update plugin manifests for ${TAG}"
             # HEAD is detached at the pinned SHA; push to the dispatched
@@ -224,29 +216,6 @@ jobs:
             git push origin "HEAD:${GITHUB_REF_NAME}"
           fi
 
-      - name: Verify publish exclusions
-        run: |
-          # R20: published artifacts must exclude the eval harness and docs
-          # (enforced by the repository-root .tesslignore; see RELEASE.md).
-          if ! output=$(tessl plugin publish . --dry-run --verbose 2>&1); then
-            echo "$output"
-            echo "::error::tessl plugin publish --dry-run failed"
-            exit 1
-          fi
-          echo "$output"
-          if echo "$output" | grep -E '(^|[[:space:]"'"'"'])(\./)?(evals|docs)/' ; then
-            echo "::error::tessl plugin publish would include evals/ or docs/ paths; fix .tesslignore before releasing"
-            exit 1
-          fi
-          echo "Publish exclusions verified: no evals/ or docs/ paths in the dry-run output."
-
-      - name: Publish to Tessl
-        run: |
-          # Score the authored Tessl scenarios at publish time. --eval-scenarios
-          # points the publisher at evals/tessl/ in the working tree; the packaged
-          # plugin still excludes all of evals/ (R20, verified above). See RELEASE.md.
-          tessl plugin publish . --eval-scenarios evals/tessl
-
       - name: Create tag
         env:
           TAG: ${{ steps.version.outputs.tag }}
@@ -263,17 +232,18 @@ jobs:
             --title "${TAG}" \
             --generate-notes
 
-  # After the GitHub release so the tag/release stay the source of truth; a
-  # failed publish is retried by dispatching publish-npm.yml with the tag,
-  # without re-releasing.
+  # publish-npm, sync-website, and github-pages all run in parallel after the
+  # GitHub release is created. Each is a separate dispatchable workflow so a
+  # failed or timed-out step can be retried independently with the existing tag
+  # without re-running the full release.
   #
-  # Dispatched rather than called as a reusable workflow: npm's trusted
-  # publisher for @dash0/agent-skills is pinned to publish-npm.yml, and npm
-  # validates the top-level workflow's filename — a workflow_call here would
-  # present release.yml and be rejected. workflow_dispatch is one of the two
-  # event types the default GITHUB_TOKEN is allowed to trigger, so this does
-  # not need a PAT. The publish run's outcome is reported on its own run,
-  # not on this one.
+  # Dispatched rather than called as reusable workflows: npm's trusted publisher
+  # for @dash0/agent-skills is pinned to publish-npm.yml, and npm validates the
+  # top-level workflow's filename — a workflow_call here would present release.yml
+  # and be rejected. The same dispatch pattern is applied to sync-website.yml and
+  # github-pages.yml for consistency. workflow_dispatch is one of the two event
+  # types the default GITHUB_TOKEN is allowed to trigger, so none of these need a
+  # PAT. Each dispatched run's outcome is reported on its own run, not on this one.
   publish-npm:
     name: Dispatch npm publish
     needs: release
@@ -290,3 +260,37 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             -f tag="${TAG}"
           echo "Dispatched publish-npm.yml for ${TAG}; its result appears on that workflow's own run."
+
+  sync-website:
+    name: Dispatch website sync
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch sync-website.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release.outputs.tag }}
+        run: |
+          gh workflow run sync-website.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            -f tag="${TAG}"
+          echo "Dispatched sync-website.yml for ${TAG}; its result appears on that workflow's own run."
+
+  github-pages:
+    name: Dispatch GitHub Pages
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch github-pages.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release.outputs.tag }}
+        run: |
+          gh workflow run github-pages.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            -f tag="${TAG}"
+          echo "Dispatched github-pages.yml for ${TAG}; its result appears on that workflow's own run."

--- a/.github/workflows/sync-website.yml
+++ b/.github/workflows/sync-website.yml
@@ -1,0 +1,54 @@
+name: Sync website
+
+# Publishes the plugin to the Tessl registry for an existing release tag.
+# Dispatched by release.yml after the GitHub release is created, and
+# dispatchable by hand to retry a failed sync without re-releasing.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to sync (e.g. v1.3.1)"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  sync:
+    name: Sync ${{ inputs.tag }} to Tessl
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
+
+      - uses: tesslio/setup-tessl@v2
+        with:
+          token: ${{ secrets.TESSL_TOKEN }}
+
+      - name: Verify publish exclusions
+        run: |
+          # R20: published artifacts must exclude the eval harness and docs
+          # (enforced by the repository-root .tesslignore; see RELEASE.md).
+          if ! output=$(tessl plugin publish . --dry-run --verbose 2>&1); then
+            echo "$output"
+            echo "::error::tessl plugin publish --dry-run failed"
+            exit 1
+          fi
+          echo "$output"
+          if echo "$output" | grep -E '(^|[[:space:]"'"'"'])(\./)?(evals|docs)/' ; then
+            echo "::error::tessl plugin publish would include evals/ or docs/ paths; fix .tesslignore before releasing"
+            exit 1
+          fi
+          echo "Publish exclusions verified: no evals/ or docs/ paths in the dry-run output."
+
+      - name: Publish to Tessl
+        run: |
+          # Score the authored Tessl scenarios at publish time. --eval-scenarios
+          # points the publisher at evals/tessl/ in the working tree; the packaged
+          # plugin still excludes all of evals/ (R20, verified above). See RELEASE.md.
+          tessl plugin publish . --eval-scenarios evals/tessl

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -67,6 +67,27 @@ The flag reads the scenarios from the working tree, which carries them regardles
 4. Click **Run workflow** to start the release.
 5. Review the generated release notes on the [releases page](https://github.com/dash0hq/agent-skills/releases) and edit them if needed to group changes by skill and clarify impact.
 
+## Retrying post-release steps
+
+Each post-release step (npm publish, Tessl sync, and GitHub Pages deploy) runs as its own dispatchable workflow so a timeout or failure can be retried independently with the existing tag, without re-running the full release.
+
+| Step | Workflow to dispatch | Input |
+|---|---|---|
+| npm publish | [`publish-npm.yml`](https://github.com/dash0hq/agent-skills/actions/workflows/publish-npm.yml) | `tag` |
+| Tessl website sync | [`sync-website.yml`](https://github.com/dash0hq/agent-skills/actions/workflows/sync-website.yml) | `tag` |
+| GitHub Pages | [`github-pages.yml`](https://github.com/dash0hq/agent-skills/actions/workflows/github-pages.yml) | `tag` |
+
+## GitHub Pages prerequisite
+
+The [`github-pages.yml`](./.github/workflows/github-pages.yml) workflow deploys the repository as a Jekyll site.
+Before the first release, enable GitHub Pages for the repository:
+
+1. Go to **Settings > Pages** in the repository.
+2. Under **Build and deployment**, set the source to **GitHub Actions**.
+
+No branch or directory needs to be selected; the workflow manages the deployment.
+GitHub creates the `github-pages` environment automatically on the first successful deployment.
+
 ## What the workflow does
 
 1. **Validate skills** — checks that every directory under `skills/` contains a `SKILL.md`.
@@ -76,7 +97,8 @@ The flag reads the scenarios from the working tree, which carries them regardles
 4. **Commit changelog** — commits the updated `CHANGELOG.md` to `main`.
 5. **Create tag** — creates and pushes an annotated `vMAJOR.MINOR.PATCH` tag on the changelog commit.
 6. **Create GitHub release** — publishes a release with auto-generated notes from the commit history since the previous tag.
-7. **Publish to npm** — publishes `@dash0/agent-skills` (the `skills/` trees only) to npmjs.com with provenance, authenticated via [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers). This runs as a separate job that dispatches [`publish-npm.yml`](./.github/workflows/publish-npm.yml) with the new tag, and the publish outcome appears on that workflow's own run rather than on the release run; the same workflow can also be [dispatched manually](https://github.com/dash0hq/agent-skills/actions/workflows/publish-npm.yml) with any existing tag — to retrofit a release cut before npm publishing existed, or to retry a failed publish without re-releasing.
+7. **Publish to npm**, **sync website**, and **deploy GitHub Pages** — three jobs that dispatch [`publish-npm.yml`](./.github/workflows/publish-npm.yml), [`sync-website.yml`](./.github/workflows/sync-website.yml), and [`github-pages.yml`](./.github/workflows/github-pages.yml) in parallel with the new tag.
+   Each dispatched run's outcome appears on its own workflow run rather than on the release run; each can also be dispatched manually to retry a failed step without re-releasing.
 
 ## Post-release verification
 


### PR DESCRIPTION
## Summary

- Moves Tessl publish out of the `release` job into a new standalone `sync-website.yml`, which mirrors the `publish-npm.yml` dispatch pattern
- Adds `github-pages.yml` for Jekyll-based GitHub Pages deployment (requires enabling Pages with "GitHub Actions" source in repo settings — documented in RELEASE.md)
- The `release` job now dispatches all three post-release workflows (`publish-npm`, `sync-website`, `github-pages`) in parallel after creating the GitHub release
- Each workflow accepts a `tag` input and can be dispatched manually to retry a failed or timed-out step without re-releasing