### PR TITLE
chore(evals): move eval scenario declarations into per-language files

### DIFF
--- a/evals/custom/scenarios/instr_browser.go
+++ b/evals/custom/scenarios/instr_browser.go
@@ -21,6 +21,10 @@ import (
 	"github.com/dash0hq/agent-skills/evals/custom/harness"
 )
 
+func init() {
+	registerScenarios(BrowserHTTP())
+}
+
 // BrowserHTTPID is the browser instrumentation scenario: page spans received
 // over OTLP/HTTP through the relay.
 const BrowserHTTPID = "instr-browser-http"

--- a/evals/custom/scenarios/instr_dotnet.go
+++ b/evals/custom/scenarios/instr_dotnet.go
@@ -16,6 +16,10 @@ import (
 	"github.com/dash0hq/agent-skills/evals/custom/harness"
 )
 
+func init() {
+	registerScenarios(DotnetHTTP(), DotnetNuGet(), DotnetEnrichment())
+}
+
 // Scenario IDs of the .NET scenarios.
 const (
 	// DotnetHTTPID is the .NET instrumentation happy path.

--- a/evals/custom/scenarios/instr_java.go
+++ b/evals/custom/scenarios/instr_java.go
@@ -1,0 +1,31 @@
+// The Java SDK instrumentation scenario: the per-language HTTP happy path
+// built on the shared sdkHTTPScenario helper (see instr_sdks.go).
+package scenarios
+
+import "github.com/dash0hq/agent-skills/evals/custom/harness"
+
+func init() {
+	registerScenarios(JavaHTTP())
+}
+
+// JavaHTTPID is the Java (javaagent) instrumentation happy path (see
+// scenarios.go for how IDs are used).
+const JavaHTTPID = "instr-java-http"
+
+// JavaServiceName is the service.name the Java scenario's prompt demands and
+// its assertions check (AE4).
+const JavaServiceName = "java-service-eval"
+
+// JavaHTTP is the Java instrumentation happy-path scenario. The fixture is a
+// Spring Boot Web service (embedded Tomcat plus Spring WebMVC) built with Maven.
+func JavaHTTP() harness.Scenario {
+	return sdkHTTPScenario(
+		JavaHTTPID,
+		"skills/otel-instrumentation/rules/sdks/java.md",
+		"evals/custom/fixtures/java-service",
+		"Java HTTP service (Maven build, Spring Boot Web)",
+		JavaServiceName,
+		`- The service runs as the container built by the Dockerfile; make the instrumentation take effect there (for example by fetching what the instrumentation needs during the image build and wiring it into the container entrypoint).`,
+		heavyScenarioTimeout,
+	)
+}

--- a/evals/custom/scenarios/instr_nextjs.go
+++ b/evals/custom/scenarios/instr_nextjs.go
@@ -1,0 +1,34 @@
+// The Next.js SDK instrumentation scenario: the per-language HTTP happy path
+// built on the shared sdkHTTPScenario helper (see instr_sdks.go).
+package scenarios
+
+import "github.com/dash0hq/agent-skills/evals/custom/harness"
+
+func init() {
+	registerScenarios(NextJSHTTP())
+}
+
+// NextJSHTTPID is the Next.js (app router) instrumentation happy path; the
+// fixture's outbound call happens server-side in a route handler (see
+// scenarios.go for how IDs are used).
+const NextJSHTTPID = "instr-nextjs-http"
+
+// NextJSServiceName is the service.name the Next.js scenario's prompt demands
+// and its assertions check (AE4).
+const NextJSServiceName = "nextjs-service-eval"
+
+// NextJSHTTP is the Next.js instrumentation happy-path scenario. The
+// assertions target server-side telemetry: the route handler's server span
+// and the client span of its outbound fetch.
+func NextJSHTTP() harness.Scenario {
+	return sdkHTTPScenario(
+		NextJSHTTPID,
+		"skills/otel-instrumentation/rules/sdks/nextjs.md",
+		"evals/custom/fixtures/nextjs-service",
+		"Next.js app-router application (the GET /checkout route handler makes the outbound call server-side)",
+		NextJSServiceName,
+		`- Only server-side instrumentation is verified in this task: the server span of the GET /checkout route handler and the client span of its outbound fetch. Client (browser) instrumentation is not exercised.
+- The service runs as the container built by the Dockerfile; make the instrumentation take effect in the production build ("next build" followed by "next start").`,
+		heavyScenarioTimeout,
+	)
+}

--- a/evals/custom/scenarios/instr_php.go
+++ b/evals/custom/scenarios/instr_php.go
@@ -1,0 +1,31 @@
+// The PHP SDK instrumentation scenario: the per-language HTTP happy path
+// built on the shared sdkHTTPScenario helper (see instr_sdks.go).
+package scenarios
+
+import "github.com/dash0hq/agent-skills/evals/custom/harness"
+
+func init() {
+	registerScenarios(PHPHTTP())
+}
+
+// PHPHTTPID is the PHP (built-in server) instrumentation happy path (see
+// scenarios.go for how IDs are used).
+const PHPHTTPID = "instr-php-http"
+
+// PHPServiceName is the service.name the PHP scenario's prompt demands and
+// its assertions check (AE4).
+const PHPServiceName = "php-service-eval"
+
+// PHPHTTP is the PHP instrumentation happy-path scenario. The fixture is a
+// single index.php served by the PHP built-in web server.
+func PHPHTTP() harness.Scenario {
+	return sdkHTTPScenario(
+		PHPHTTPID,
+		"skills/otel-instrumentation/rules/sdks/php.md",
+		"evals/custom/fixtures/php-service",
+		"PHP HTTP service (a single index.php served by the PHP built-in web server)",
+		PHPServiceName,
+		`- The service runs as the container built by the Dockerfile; make the instrumentation take effect there (for example by installing Composer packages and any required PHP extension during the image build).`,
+		heavyScenarioTimeout,
+	)
+}

--- a/evals/custom/scenarios/instr_python.go
+++ b/evals/custom/scenarios/instr_python.go
@@ -1,0 +1,30 @@
+// The Python SDK instrumentation scenario: the per-language HTTP happy path
+// built on the shared sdkHTTPScenario helper (see instr_sdks.go).
+package scenarios
+
+import "github.com/dash0hq/agent-skills/evals/custom/harness"
+
+func init() {
+	registerScenarios(PythonHTTP())
+}
+
+// PythonHTTPID is the Python (Flask) instrumentation happy path (see
+// scenarios.go for how IDs are used).
+const PythonHTTPID = "instr-python-http"
+
+// PythonServiceName is the service.name the Python scenario's prompt demands
+// and its assertions check (AE4).
+const PythonServiceName = "python-service-eval"
+
+// PythonHTTP is the Python instrumentation happy-path scenario.
+func PythonHTTP() harness.Scenario {
+	return sdkHTTPScenario(
+		PythonHTTPID,
+		"skills/otel-instrumentation/rules/sdks/python.md",
+		"evals/custom/fixtures/python-service",
+		"Python Flask HTTP service",
+		PythonServiceName,
+		`- The service runs as the container built by the Dockerfile; make the instrumentation take effect there (for example by adjusting the dependency list and the container command).`,
+		scenarioTimeout,
+	)
+}

--- a/evals/custom/scenarios/instr_ruby.go
+++ b/evals/custom/scenarios/instr_ruby.go
@@ -1,0 +1,31 @@
+// The Ruby SDK instrumentation scenario: the per-language HTTP happy path
+// built on the shared sdkHTTPScenario helper (see instr_sdks.go).
+package scenarios
+
+import "github.com/dash0hq/agent-skills/evals/custom/harness"
+
+func init() {
+	registerScenarios(RubyHTTP())
+}
+
+// RubyHTTPID is the Ruby (Rack on WEBrick) instrumentation happy path (see
+// scenarios.go for how IDs are used).
+const RubyHTTPID = "instr-ruby-http"
+
+// RubyServiceName is the service.name the Ruby scenario's prompt demands and
+// its assertions check (AE4).
+const RubyServiceName = "ruby-service-eval"
+
+// RubyHTTP is the Ruby instrumentation happy-path scenario. The fixture is a
+// plain Rack application served by WEBrick via rackup.
+func RubyHTTP() harness.Scenario {
+	return sdkHTTPScenario(
+		RubyHTTPID,
+		"skills/otel-instrumentation/rules/sdks/ruby.md",
+		"evals/custom/fixtures/ruby-service",
+		"Ruby HTTP service (a plain Rack application served by WEBrick via rackup)",
+		RubyServiceName,
+		`- The service runs as the container built by the Dockerfile; make the instrumentation take effect there (for example by adjusting the Gemfile and initializing the SDK before the Rack application starts).`,
+		scenarioTimeout,
+	)
+}

--- a/evals/custom/scenarios/instr_scala.go
+++ b/evals/custom/scenarios/instr_scala.go
@@ -1,0 +1,32 @@
+// The Scala SDK instrumentation scenario: the per-language HTTP happy path
+// built on the shared sdkHTTPScenario helper (see instr_sdks.go).
+package scenarios
+
+import "github.com/dash0hq/agent-skills/evals/custom/harness"
+
+func init() {
+	registerScenarios(ScalaHTTP())
+}
+
+// ScalaHTTPID is the Scala (sbt, javaagent) instrumentation happy path (see
+// scenarios.go for how IDs are used).
+const ScalaHTTPID = "instr-scala-http"
+
+// ScalaServiceName is the service.name the Scala scenario's prompt demands
+// and its assertions check (AE4).
+const ScalaServiceName = "scala-service-eval"
+
+// ScalaHTTP is the Scala instrumentation happy-path scenario. The fixture is
+// an sbt project run via "sbt run" in the container, so sbt-level agent
+// wiring (as the Scala rule file teaches) takes effect at start.
+func ScalaHTTP() harness.Scenario {
+	return sdkHTTPScenario(
+		ScalaHTTPID,
+		"skills/otel-instrumentation/rules/sdks/scala.md",
+		"evals/custom/fixtures/scala-service",
+		"Scala HTTP service (an sbt project; the container runs it via \"sbt run\")",
+		ScalaServiceName,
+		`- The service runs as the container built by the Dockerfile via "sbt run"; make the instrumentation take effect there (the build may resolve new dependencies, but the running container has no network access beyond the telemetry endpoint).`,
+		heavyScenarioTimeout,
+	)
+}

--- a/evals/custom/scenarios/instr_sdks.go
+++ b/evals/custom/scenarios/instr_sdks.go
@@ -1,57 +1,14 @@
-// The U4 SDK instrumentation scenarios: the remaining 8 SDK rule files after
-// the U3 Go and Node.js proving ground. This file declares the additive
-// registration mechanism (registerScenarios) plus the 6 straightforward
-// per-language HTTP happy paths; the .NET scenarios (including the 2 manually-found
-// regressions) live in instr_dotnet.go and the browser scenario in
-// instr_browser.go.
+// Shared helpers of the per-language SDK instrumentation scenarios. Each
+// language declares its scenarios in its own instr_<language>.go file and
+// self-registers them via registerScenarios (see register.go); this file
+// carries only what those files share: the heavy-build timeout and the
+// sdkHTTPScenario happy-path builder.
 package scenarios
 
 import (
 	"time"
 
 	"github.com/dash0hq/agent-skills/evals/custom/harness"
-)
-
-func init() {
-	registerScenarios(
-		PythonHTTP(), JavaHTTP(), RubyHTTP(), PHPHTTP(), ScalaHTTP(),
-		DotnetHTTP(), DotnetNuGet(), DotnetEnrichment(),
-		NextJSHTTP(), BrowserHTTP(),
-	)
-}
-
-// Scenario IDs of the U4 per-language HTTP happy paths (see scenarios.go for
-// how IDs are used).
-const (
-	// PythonHTTPID is the Python (Flask) instrumentation happy path.
-	PythonHTTPID = "instr-python-http"
-	// JavaHTTPID is the Java (javaagent) instrumentation happy path.
-	JavaHTTPID = "instr-java-http"
-	// RubyHTTPID is the Ruby (Rack on WEBrick) instrumentation happy path.
-	RubyHTTPID = "instr-ruby-http"
-	// PHPHTTPID is the PHP (built-in server) instrumentation happy path.
-	PHPHTTPID = "instr-php-http"
-	// ScalaHTTPID is the Scala (sbt, javaagent) instrumentation happy path.
-	ScalaHTTPID = "instr-scala-http"
-	// NextJSHTTPID is the Next.js (app router) instrumentation happy path;
-	// the fixture's outbound call happens server-side in a route handler.
-	NextJSHTTPID = "instr-nextjs-http"
-)
-
-// Service names the U4 prompts demand and the assertions check (AE4).
-const (
-	// PythonServiceName is the service.name the Python scenario requires.
-	PythonServiceName = "python-service-eval"
-	// JavaServiceName is the service.name the Java scenario requires.
-	JavaServiceName = "java-service-eval"
-	// RubyServiceName is the service.name the Ruby scenario requires.
-	RubyServiceName = "ruby-service-eval"
-	// PHPServiceName is the service.name the PHP scenario requires.
-	PHPServiceName = "php-service-eval"
-	// ScalaServiceName is the service.name the Scala scenario requires.
-	ScalaServiceName = "scala-service-eval"
-	// NextJSServiceName is the service.name the Next.js scenario requires.
-	NextJSServiceName = "nextjs-service-eval"
 )
 
 // heavyScenarioTimeout is the wall-clock budget for the scenarios whose
@@ -84,90 +41,4 @@ Instrumentation goals:
 		TelemetryTimeout: telemetryTimeout,
 		Assert:           assertHTTPTraces(serviceName),
 	}
-}
-
-// PythonHTTP is the Python instrumentation happy-path scenario.
-func PythonHTTP() harness.Scenario {
-	return sdkHTTPScenario(
-		PythonHTTPID,
-		"skills/otel-instrumentation/rules/sdks/python.md",
-		"evals/custom/fixtures/python-service",
-		"Python Flask HTTP service",
-		PythonServiceName,
-		`- The service runs as the container built by the Dockerfile; make the instrumentation take effect there (for example by adjusting the dependency list and the container command).`,
-		scenarioTimeout,
-	)
-}
-
-// JavaHTTP is the Java instrumentation happy-path scenario. The fixture is a
-// Spring Boot Web service (embedded Tomcat plus Spring WebMVC) built with Maven.
-func JavaHTTP() harness.Scenario {
-	return sdkHTTPScenario(
-		JavaHTTPID,
-		"skills/otel-instrumentation/rules/sdks/java.md",
-		"evals/custom/fixtures/java-service",
-		"Java HTTP service (Maven build, Spring Boot Web)",
-		JavaServiceName,
-		`- The service runs as the container built by the Dockerfile; make the instrumentation take effect there (for example by fetching what the instrumentation needs during the image build and wiring it into the container entrypoint).`,
-		heavyScenarioTimeout,
-	)
-}
-
-// RubyHTTP is the Ruby instrumentation happy-path scenario. The fixture is a
-// plain Rack application served by WEBrick via rackup.
-func RubyHTTP() harness.Scenario {
-	return sdkHTTPScenario(
-		RubyHTTPID,
-		"skills/otel-instrumentation/rules/sdks/ruby.md",
-		"evals/custom/fixtures/ruby-service",
-		"Ruby HTTP service (a plain Rack application served by WEBrick via rackup)",
-		RubyServiceName,
-		`- The service runs as the container built by the Dockerfile; make the instrumentation take effect there (for example by adjusting the Gemfile and initializing the SDK before the Rack application starts).`,
-		scenarioTimeout,
-	)
-}
-
-// PHPHTTP is the PHP instrumentation happy-path scenario. The fixture is a
-// single index.php served by the PHP built-in web server.
-func PHPHTTP() harness.Scenario {
-	return sdkHTTPScenario(
-		PHPHTTPID,
-		"skills/otel-instrumentation/rules/sdks/php.md",
-		"evals/custom/fixtures/php-service",
-		"PHP HTTP service (a single index.php served by the PHP built-in web server)",
-		PHPServiceName,
-		`- The service runs as the container built by the Dockerfile; make the instrumentation take effect there (for example by installing Composer packages and any required PHP extension during the image build).`,
-		heavyScenarioTimeout,
-	)
-}
-
-// ScalaHTTP is the Scala instrumentation happy-path scenario. The fixture is
-// an sbt project run via "sbt run" in the container, so sbt-level agent
-// wiring (as the Scala rule file teaches) takes effect at start.
-func ScalaHTTP() harness.Scenario {
-	return sdkHTTPScenario(
-		ScalaHTTPID,
-		"skills/otel-instrumentation/rules/sdks/scala.md",
-		"evals/custom/fixtures/scala-service",
-		"Scala HTTP service (an sbt project; the container runs it via \"sbt run\")",
-		ScalaServiceName,
-		`- The service runs as the container built by the Dockerfile via "sbt run"; make the instrumentation take effect there (the build may resolve new dependencies, but the running container has no network access beyond the telemetry endpoint).`,
-		heavyScenarioTimeout,
-	)
-}
-
-// NextJSHTTP is the Next.js instrumentation happy-path scenario. The
-// assertions target server-side telemetry: the route handler's server span
-// and the client span of its outbound fetch.
-func NextJSHTTP() harness.Scenario {
-	return sdkHTTPScenario(
-		NextJSHTTPID,
-		"skills/otel-instrumentation/rules/sdks/nextjs.md",
-		"evals/custom/fixtures/nextjs-service",
-		"Next.js app-router application (the GET /checkout route handler makes the outbound call server-side)",
-		NextJSServiceName,
-		`- Only server-side instrumentation is verified in this task: the server span of the GET /checkout route handler and the client span of its outbound fetch. Client (browser) instrumentation is not exercised.
-- The service runs as the container built by the Dockerfile; make the instrumentation take effect in the production build ("next build" followed by "next start").`,
-		heavyScenarioTimeout,
-	)
 }


### PR DESCRIPTION
Fixes #131.

Implements reading 1 of the issue (eval code structure): `instr_sdks.go` declared the Python, Java, Ruby, PHP, Scala, and Next.js scenarios in one shared file with a single central `init()` that also registered the .NET and browser scenarios. This completes the self-registration pattern `registerScenarios` (see `register.go`) exists for.

On reading 2 (skill content): confirmed already satisfied — the shared testing/verification guidance in `skills/otel-instrumentation/rules/validation.md` is language-neutral (Collector/backend checks), so there is nothing to move into `sdks/*.md`.

## Changes

- New per-language files, each with its scenario func, ID constant, service-name constant, and its own `init()`: `instr_python.go`, `instr_java.go`, `instr_ruby.go`, `instr_php.go`, `instr_scala.go`, `instr_nextjs.go`.
- `instr_dotnet.go` and `instr_browser.go` now register their own scenarios instead of relying on the central `init()`.
- `instr_sdks.go` shrinks to the shared SDK helpers (`heavyScenarioTimeout`, `sdkHTTPScenario`), mirroring how `scenarios.go` keeps the shared declarations of the base set; its header comment now says so.