### PR TITLE
fix(otel-instrumentation): newest published is not newest usable — check toolchain compatibility

### DIFF
--- a/skills/otel-instrumentation/rules/sdks/go.md
+++ b/skills/otel-instrumentation/rules/sdks/go.md
@@ -47,6 +47,15 @@ go list -m -versions go.opentelemetry.io/contrib/instrumentation/net/http/otelht
 The module proxy lists every published version; a module it does not know is not a published instrumentation.
 Add modules with `go get <module>@latest` followed by `go mod tidy`, which resolves real versions and prunes the manifest.
 
+The newest published release is not always usable: a module version's `go` directive must be satisfied by the project's toolchain — the `go` line in `go.mod` **and** the Go version of the build environment (Go container base images set `GOTOOLCHAIN=local`, so a builder like `golang:1.24` cannot auto-download the newer toolchain a dependency demands, and `go mod download` fails with `requires go >= ...`).
+A version's directive is one request away:
+
+```bash
+curl -s https://proxy.golang.org/go.opentelemetry.io/otel/@v/v1.45.0.mod | grep '^go '
+```
+
+When the newest release requires a newer toolchain than the project has, walk `go list -m -versions` down to the newest release whose directive the toolchain satisfies and pin that — or upgrade the toolchain deliberately (go.mod directive, builder images, CI) as its own visible change.
+
 ## Environment variables
 
 All environment variables that control the SDK behavior:

--- a/skills/otel-instrumentation/rules/sdks/nodejs.md
+++ b/skills/otel-instrumentation/rules/sdks/nodejs.md
@@ -37,6 +37,7 @@ npm view @opentelemetry/instrumentation-undici deprecated      # prints the noti
 
 A range that matches no published version prints nothing: `npm view '<pkg>@^1.2.3' version`.
 Prefer `npm install <pkg>` (no version) over hand-editing `package.json`, so npm resolves and records the real latest version.
+Check the package's runtime requirement against the project's Node.js version (`engines` in `package.json`, base images in Dockerfiles, `.nvmrc`) with `npm view <pkg> engines` — npm only warns on an engines mismatch by default, so an incompatible package installs fine and breaks at runtime.
 
 ## Environment variables
 

--- a/skills/otel-instrumentation/rules/sdks/python.md
+++ b/skills/otel-instrumentation/rules/sdks/python.md
@@ -42,6 +42,8 @@ pip index versions opentelemetry-instrumentation-flask  # existence and publishe
 A library missing from the bootstrap output has no current instrumentation — retired instrumentations (such as elasticsearch) still install from PyPI at their last release but are no longer maintained or shipped.
 Do not hand-pin such a package; instrument the library manually instead.
 
+pip enforces `Requires-Python` natively, resolving to the newest release compatible with the interpreter — but only the interpreter pip runs under, so run the resolution (or `pip index versions`) under the same Python version the project builds and deploys with (base image, CI), not whatever is on your PATH.
+
 ## Environment variables
 
 All environment variables that control the SDK behavior:

--- a/skills/otel-instrumentation/rules/verify-dependencies.md
+++ b/skills/otel-instrumentation/rules/verify-dependencies.md
@@ -4,22 +4,25 @@ Never write an instrumentation package name or version from memory.
 Knowledge of package ecosystems goes stale in both directions: versions get invented that were never published, and packages that once existed get retired with no further releases.
 A retired package still installs from the registry at its last release, so a successful install alone does not prove the instrumentation is current.
 
-Before adding any instrumentation dependency to a manifest, verify all three against the package registry:
+Before adding any instrumentation dependency to a manifest, verify all four against the package registry:
 
 1. **Existence** — the package name is real.
 2. **Version** — the exact version or range you reference has been published.
 3. **Currency** — the package is not deprecated, yanked, or retired, and has a release compatible with the SDK version you target.
+4. **Compatibility** — the version's runtime or toolchain requirement is satisfied by the project: the newest published release is not the newest usable one when it demands a newer language toolchain, runtime, or framework than the project builds and runs on.
 
 ## Decision process
 
 1. Prefer the package manager's add command without a version (`npm install <pkg>`, `go get <module>@latest`, `pip install <pkg>`, `bundle add <gem>`, `composer require <pkg>`, `dotnet add package <id>`).
    It resolves the latest published version from the registry and fails loudly when the package does not exist.
 2. When you must write a manifest entry by hand, first run the lookup command from your language's section (indexed below) and copy the version it reports.
-3. When the lookup shows the package is deprecated, yanked, or has no recent release, do not add it: fall back to the auto-instrumentation path or manual instrumentation per the language's SDK rule, and state why.
+3. Check the version's runtime or toolchain requirement against the project before pinning it: the project's manifest (for example the `go` directive in `go.mod`, `engines` in `package.json`) and its build and runtime environments (base images in Dockerfiles, CI toolchains).
+   When the newest release requires a newer toolchain than the project has, pin the newest release that satisfies the project's toolchain instead — or upgrade the toolchain deliberately, as its own visible change (manifest directive, base images, CI), never as a side effect of a dependency bump.
+4. When the lookup shows the package is deprecated, yanked, or has no recent release, do not add it: fall back to the auto-instrumentation path or manual instrumentation per the language's SDK rule, and state why.
    When this means removing a dependency that is already in the manifest, follow [Dropping an existing dependency](#dropping-an-existing-dependency).
-4. When the lookup finds no package at all, do not invent a name: check the [OpenTelemetry registry](https://opentelemetry.io/ecosystem/registry/) for the library, and if nothing current exists, instrument manually per [spans](./spans.md) and the SDK rule.
-5. Never guess a version to complete a manifest entry.
-   A wrong pin fails the build (`npm error notarget`, `go: no matching versions`), or worse, resolves to an incompatible release.
+5. When the lookup finds no package at all, do not invent a name: check the [OpenTelemetry registry](https://opentelemetry.io/ecosystem/registry/) for the library, and if nothing current exists, instrument manually per [spans](./spans.md) and the SDK rule.
+6. Never guess a version to complete a manifest entry.
+   A wrong pin fails the build (`npm error notarget`, `go: no matching versions`, `go: module ... requires go >= ...`), or worse, resolves to an incompatible release.
 
 <!-- eval:bad -->
 ```json


### PR DESCRIPTION
Fixes #134.

The #128 recipe fixed its failure mode (zero compile errors, rubric 1.0 across all reps), and the residual skills-on failures moved to `go mod download` — the agent pinned `otel@v1.45.0`/`otelhttp@v0.70.0` (real, current versions, declaring `go 1.25.0`) against a `golang:1.24` builder where `GOTOOLCHAIN=local` forbids auto-upgrade. The unaided baseline passed with older-from-memory versions: newest **published** is not newest **usable**.