### PR TITLE
fix(otel-instrumentation): keep the lockfile in step with the manifest

### DIFF
--- a/skills/otel-instrumentation/rules/sdks/go.md
+++ b/skills/otel-instrumentation/rules/sdks/go.md
@@ -56,6 +56,23 @@ curl -s https://proxy.golang.org/go.opentelemetry.io/otel/@v/v1.45.0.mod | grep 
 
 When the newest release requires a newer toolchain than the project has, walk `go list -m -versions` down to the newest release whose directive the toolchain satisfies and pin that — or upgrade the toolchain deliberately (go.mod directive, builder images, CI) as its own visible change.
 
+`go.sum` must move with `go.mod`: its hashes cannot be hand-written, so after any `go.mod` edit, regenerate it with `go mod tidy`.
+A `go.mod` that requires modules missing from `go.sum` fails every subsequent build:
+
+```text
+main.go:23:2: missing go.sum entry for module providing package go.opentelemetry.io/otel/sdk/resource
+```
+
+When the `go.mod` edit happens somewhere the Go toolchain cannot run — per [verify-dependencies](../verify-dependencies.md#keeping-the-lockfile-in-step) — and the project builds in a container, make the builder stage regenerate the module metadata itself before compiling:
+
+```dockerfile
+FROM golang:1.24 AS builder
+WORKDIR /src
+COPY . .
+RUN go mod tidy
+RUN go build -o /service .
+```
+
 ## Environment variables
 
 All environment variables that control the SDK behavior:

--- a/skills/otel-instrumentation/rules/sdks/nextjs.md
+++ b/skills/otel-instrumentation/rules/sdks/nextjs.md
@@ -25,6 +25,7 @@ Full-stack OpenTelemetry setup for Next.js 13+ with App Router. Server-side uses
 ## Verifying dependencies
 
 Never write a package name or version into `package.json` from memory; verify it against the npm registry first (`npm view <pkg> version`, `npm view <pkg> deprecated`), per [verify-dependencies](../verify-dependencies.md), and prefer `npm install <pkg>` (no version) so npm resolves the real latest version.
+The npm manifest-and-lockfile rule applies unchanged: a hand-edited `package.json` desynchronizes `package-lock.json` and `npm ci` fails on the mismatch — follow [nodejs](./nodejs.md#verifying-dependencies).
 
 ## Quick Start
 

--- a/skills/otel-instrumentation/rules/sdks/nodejs.md
+++ b/skills/otel-instrumentation/rules/sdks/nodejs.md
@@ -39,6 +39,17 @@ A range that matches no published version prints nothing: `npm view '<pkg>@^1.2.
 Prefer `npm install <pkg>` (no version) over hand-editing `package.json`, so npm resolves and records the real latest version.
 Check the package's runtime requirement against the project's Node.js version (`engines` in `package.json`, base images in Dockerfiles, `.nvmrc`) with `npm view <pkg> engines` — npm only warns on an engines mismatch by default, so an incompatible package installs fine and breaks at runtime.
 
+`package-lock.json` must move with `package.json`: a hand-edited manifest leaves the lockfile stale, and `npm ci` fails on the mismatch by design:
+
+```text
+npm error code EUSAGE
+npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
+npm error Missing: @opentelemetry/instrumentation-undici@0.15.0 from lock file
+```
+
+Regenerate the lockfile where npm runs (`npm install` rewrites it) per [verify-dependencies](../verify-dependencies.md#keeping-the-lockfile-in-step).
+Only as a fallback, when no environment with npm exists outside the image build, have the builder stage reconcile by running `npm install` instead of `npm ci` — this trades away the exact-lockfile reproducibility `npm ci` guarantees, so prefer regenerating the lockfile and keeping `npm ci`.
+
 ## Environment variables
 
 All environment variables that control the SDK behavior:

--- a/skills/otel-instrumentation/rules/sdks/php.md
+++ b/skills/otel-instrumentation/rules/sdks/php.md
@@ -66,6 +66,10 @@ composer show --available open-telemetry/opentelemetry-auto-slim
 
 Prefer `composer require <pkg>` (no version) over hand-editing `composer.json`, so Composer resolves the real latest version.
 
+`composer.lock` must move with `composer.json`: `composer install` against a stale lockfile warns (`Warning: The lock file is not up to date with the latest changes in composer.json.`), and since Composer 2.5 it fails outright when a required package is missing from the lockfile (`Required package "..." is not present in the lock file.`).
+Regenerate the lockfile where Composer runs with `composer update <pkg>` scoped to the touched package, per [verify-dependencies](../verify-dependencies.md#keeping-the-lockfile-in-step).
+Only as a fallback, when no environment with Composer exists outside the image build, have the builder stage run the same scoped `composer update <pkg>` before `composer install`.
+
 ## Environment variables
 
 All environment variables that control the SDK behavior:

--- a/skills/otel-instrumentation/rules/sdks/python.md
+++ b/skills/otel-instrumentation/rules/sdks/python.md
@@ -44,6 +44,8 @@ Do not hand-pin such a package; instrument the library manually instead.
 
 pip enforces `Requires-Python` natively, resolving to the newest release compatible with the interpreter — but only the interpreter pip runs under, so run the resolution (or `pip index versions`) under the same Python version the project builds and deploys with (base image, CI), not whatever is on your PATH.
 
+Plain `requirements.txt` carries no lockfile, so there is nothing to regenerate; projects locked with Poetry, uv, or Pipenv follow the manifest-and-lockfile rule in [verify-dependencies](../verify-dependencies.md#keeping-the-lockfile-in-step) — regenerate the lockfile (`poetry lock`, `uv lock`, `pipenv lock`) with every manifest edit.
+
 ## Environment variables
 
 All environment variables that control the SDK behavior:

--- a/skills/otel-instrumentation/rules/sdks/ruby.md
+++ b/skills/otel-instrumentation/rules/sdks/ruby.md
@@ -35,6 +35,10 @@ gem info --remote opentelemetry-instrumentation-rails
 
 Prefer `bundle add <gem>` (no version) over hand-editing the `Gemfile`, so Bundler resolves the real latest version.
 
+`Gemfile.lock` must move with the `Gemfile`: frozen installs (`BUNDLE_FROZEN=true`, `bundle config set frozen true`, deployment mode) refuse to install after a `Gemfile` change, listing the drift (`You have added to the Gemfile:`) and telling you to run `bundle install` elsewhere and commit the updated `Gemfile.lock`.
+Regenerate the lockfile where Bundler runs — `bundle lock` resolves and writes `Gemfile.lock` without installing — per [verify-dependencies](../verify-dependencies.md#keeping-the-lockfile-in-step).
+Only as a fallback, when no environment with Bundler exists outside the image build, have the builder stage reconcile with a non-frozen `bundle install` — frozen installs are what keep image builds reproducible, so prefer regenerating the lockfile and keeping them frozen.
+
 ## Environment variables
 
 All environment variables that control the SDK behavior:

--- a/skills/otel-instrumentation/rules/verify-dependencies.md
+++ b/skills/otel-instrumentation/rules/verify-dependencies.md
@@ -18,10 +18,11 @@ Before adding any instrumentation dependency to a manifest, verify all four agai
 2. When you must write a manifest entry by hand, first run the lookup command from your language's section (indexed below) and copy the version it reports.
 3. Check the version's runtime or toolchain requirement against the project before pinning it: the project's manifest (for example the `go` directive in `go.mod`, `engines` in `package.json`) and its build and runtime environments (base images in Dockerfiles, CI toolchains).
    When the newest release requires a newer toolchain than the project has, pin the newest release that satisfies the project's toolchain instead — or upgrade the toolchain deliberately, as its own visible change (manifest directive, base images, CI), never as a side effect of a dependency bump.
-4. When the lookup shows the package is deprecated, yanked, or has no recent release, do not add it: fall back to the auto-instrumentation path or manual instrumentation per the language's SDK rule, and state why.
+4. After any manifest edit, bring the lockfile in step per [Keeping the lockfile in step](#keeping-the-lockfile-in-step): lockfile entries cannot be hand-written, and a stale lockfile fails strict installs and Go builds.
+5. When the lookup shows the package is deprecated, yanked, or has no recent release, do not add it: fall back to the auto-instrumentation path or manual instrumentation per the language's SDK rule, and state why.
    When this means removing a dependency that is already in the manifest, follow [Dropping an existing dependency](#dropping-an-existing-dependency).
-5. When the lookup finds no package at all, do not invent a name: check the [OpenTelemetry registry](https://opentelemetry.io/ecosystem/registry/) for the library, and if nothing current exists, instrument manually per [spans](./spans.md) and the SDK rule.
-6. Never guess a version to complete a manifest entry.
+6. When the lookup finds no package at all, do not invent a name: check the [OpenTelemetry registry](https://opentelemetry.io/ecosystem/registry/) for the library, and if nothing current exists, instrument manually per [spans](./spans.md) and the SDK rule.
+7. Never guess a version to complete a manifest entry.
    A wrong pin fails the build (`npm error notarget`, `go: no matching versions`, `go: module ... requires go >= ...`), or worse, resolves to an incompatible release.
 
 <!-- eval:bad -->
@@ -34,6 +35,16 @@ Before adding any instrumentation dependency to a manifest, verify all four agai
 ```
 
 The version above was written from memory; no `0.57.x` release of that package was ever published, and `npm install` fails with `npm error code ETARGET`.
+
+## Keeping the lockfile in step
+
+A dependency manifest and its lockfile move together: `go.mod` with `go.sum`, `package.json` with `package-lock.json`, `Gemfile` with `Gemfile.lock`, and `composer.json` with `composer.lock`.
+The lockfile records resolver output and content hashes that only the package manager can compute, so a lockfile entry cannot be hand-written.
+Editing the manifest without regenerating the lockfile breaks the next build: strict installs refuse the mismatch by design (`npm ci`, frozen Bundler installs, Composer installing from a lockfile that no longer satisfies `composer.json`), and Go refuses to compile (`missing go.sum entry for module providing package ...`).
+
+Regenerate the lockfile with the ecosystem's lock-refreshing command (`go mod tidy`, `npm install`, `bundle lock`, `composer update <pkg>`) in the same change as every manifest edit, and ship both files together.
+When the edit happens somewhere the toolchain cannot run — the change is applied through a web interface or a review suggestion, made by a CI bot or dependency tooling, or the project only builds inside a container — regenerate the lockfile where the toolchain does run.
+For container builds, that place is the builder stage itself: make it self-sufficient by regenerating the lockfile before the build or install step, using the command from the language's "Verifying dependencies" section (indexed below).
 
 ## Dropping an existing dependency
 


### PR DESCRIPTION
Fixes #136.

## What

Adds the manifest-and-lockfile rule the skill was missing, in environment-agnostic build-robustness framing (edits made where the toolchain cannot run: CI bots, dependency tooling, web-applied suggestions, docker-only workflows):

- **`verify-dependencies.md`**: new "Keeping the lockfile in step" section (manifest and lockfile move together; lockfile hashes cannot be hand-written; regenerate where the toolchain runs; for container builds make the builder stage self-sufficient), plus a new Decision process step 4 pointing at it (former steps 4–6 renumbered 5–7).
- **`go.md`**: after any `go.mod` edit regenerate `go.sum` with `go mod tidy`; when the edit happens where Go cannot run, `RUN go mod tidy` in the builder stage before `go build`. Includes the measured failure string (`missing go.sum entry for module providing package ...`) so agents recognize it.
- **`nodejs.md`**: `npm ci` fails on a `package.json`/`package-lock.json` mismatch by design (verbatim `EUSAGE` transcript); regenerate the lockfile, or as a fallback reconcile with `npm install` — stating that this trades away `npm ci`'s reproducibility guarantee.
- **`ruby.md`**: frozen installs (`BUNDLE_FROZEN`, deployment mode) refuse a changed `Gemfile`; `bundle lock` regenerates without installing.
- **`php.md`**: `composer install` warns on a stale lock and, since Composer 2.5, fails when a required package is missing from it; regenerate with `composer update <pkg>` scoped to the touched package.
- **`python.md`**: one line — plain `requirements.txt` has no lockfile; Poetry/uv/Pipenv projects follow the same rule.
- **`nextjs.md`**: one line deferring to the nodejs rule.